### PR TITLE
Update version references to 0.60

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,12 +7,12 @@
     <title>OW</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.50b">
+    <link rel="stylesheet" href="styles.css?v=0.60">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.50b</div>
+        <div id="version-display">v0.60</div>
     <div id="vr-message">Regardez la scène dans Steam VR</div>
 
     <div id="visual-panel" class="ui-panel">
@@ -82,7 +82,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.49"></script>
+    <script type="module" src="main.js?v=0.60"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- update stylesheet cache-busting parameter to 0.60
- refresh displayed version number to v0.60
- align main.js cache-busting parameter with version 0.60

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1a220fb408323b9bafdd11b20b4ed