### PR TITLE
feat: add Stroop size control for v0.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v0.65 (2025-09-25)
+
+* Ajout d'un curseur de taille pour le Stroop Test permettant d'affiner l'affichage du mot de 80 % à 300 %.
+* Mise à jour des métadonnées et du cache service worker vers la version 0.65.
+
+## v0.64 (2025-09-24)
+
+* Harmonisation visuelle des panneaux « Stimulation » et « Exercice » pour une présentation cohérente.
+* Suppression de l'espace fantôme du sous-menu d'exercice lorsqu'aucune option n'est sélectionnée.
+
+## v0.63 (2025-09-23)
+
+* Mise à jour des métadonnées pour afficher la version 0.63 dans l'application et le service worker.
+
 ## v0.50b (2025-07-15)
 
 - **Correction de Bug:** Les vitesses pour les modules Optocinétique et Flux Optique ne fonctionnaient plus.

--- a/index.html
+++ b/index.html
@@ -4,20 +4,27 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW</title>
+    <title>OW v0.65</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.50b">
+    <link rel="stylesheet" href="styles.css?v=0.65">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.50b</div>
+        <div id="version-display">v0.65</div>
     <div id="vr-message">Regardez la scène dans Steam VR</div>
 
     <div id="visual-panel" class="ui-panel">
-        <div><label for="visual-select">Stimulation</label><select id="visual-select"><option value="optokinetic">Optocinétique</option><option value="opticalFlow">Flux Optique</option>        <option value="rotatingCube">Cube Rotatif</option>
-        <option value="heights">Hauteurs</option></select></div>
+        <div class="panel-section">
+            <label for="visual-select">Stimulation</label>
+            <select id="visual-select">
+                <option value="optokinetic">Optocinétique</option>
+                <option value="opticalFlow">Flux Optique</option>
+                <option value="rotatingCube">Cube Rotatif</option>
+                <option value="heights">Hauteurs</option>
+            </select>
+        </div>
     </div>
 
     <div id="controls" class="ui-panel">
@@ -59,8 +66,16 @@
     </div>
 
     <div id="exercise-panel" class="ui-panel">
-        <div><label for="exercise-select">Exercice</label><select id="exercise-select"><option value="none" selected>Aucun</option><option value="targetPointer">Cible & Pointeur</option><option value="goNoGo">Go / No-Go</option><option value="stroop">Stroop Test</option></select></div>
-        <div id="exercise-submenu"></div>
+        <div class="panel-section">
+            <label for="exercise-select">Exercice</label>
+            <select id="exercise-select">
+                <option value="none" selected>Aucun</option>
+                <option value="targetPointer">Cible &amp; Pointeur</option>
+                <option value="goNoGo">Go / No-Go</option>
+                <option value="stroop">Stroop Test</option>
+            </select>
+        </div>
+        <div id="exercise-submenu" class="panel-section panel-section--submenu"></div>
     </div>
 
     <a-scene id="scene" exercise-ticker fog="type: linear; color: #111; near: 5; far: 200">
@@ -82,7 +97,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.49"></script>
+    <script type="module" src="main.js?v=0.65"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/modules/stroop.js
+++ b/modules/stroop.js
@@ -50,6 +50,11 @@ export const exerciseModule = {
                 <input type="range" id="stroop-speed-slider" min="1" max="5" value="2" step="0.5">
                 <span id="stroop-speed-value">2s</span>
             </div>
+            <div>
+                <label for="stroop-size-slider">Taille du mot</label>
+                <input type="range" id="stroop-size-slider" min="0.8" max="3" value="1" step="0.1">
+                <span id="stroop-size-value">100%</span>
+            </div>
         `;
 
         // Create text element
@@ -57,6 +62,7 @@ export const exerciseModule = {
         textElement.setAttribute('id', 'stroop-text');
         textElement.setAttribute('align', 'center');
         textElement.setAttribute('width', '6');
+        textElement.setAttribute('scale', '1 1 1');
         rig.appendChild(textElement);
 
         positionElement();
@@ -69,11 +75,19 @@ export const exerciseModule = {
         // Event listener for slider
         const speedSlider = document.getElementById('stroop-speed-slider');
         const speedValue = document.getElementById('stroop-speed-value');
+        const sizeSlider = document.getElementById('stroop-size-slider');
+        const sizeValue = document.getElementById('stroop-size-value');
         speedSlider.addEventListener('input', (event) => {
             speed = event.target.value * 1000;
             speedValue.textContent = `${event.target.value}s`;
             clearInterval(stroopInterval);
             stroopInterval = setInterval(updateStroop, speed);
+        });
+
+        sizeSlider.addEventListener('input', (event) => {
+            const scale = parseFloat(event.target.value);
+            sizeValue.textContent = `${Math.round(scale * 100)}%`;
+            textElement.setAttribute('scale', `${scale} ${scale} ${scale}`);
         });
     },
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const CACHE_NAME = 'opto-vr-cache-v0.50b';
+const CACHE_NAME = 'opto-vr-cache-v0.65';
 const URLS_TO_CACHE = [
   'index.html',
   'styles.css',

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,11 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; }
 .ui-panel label, .ui-panel span, .ui-panel button, .ui-panel select { font-weight: bold; font-size: 1.1em; padding: 5px 10px; border-radius: 5px; display: block; width: 100%; box-sizing: border-box; margin-bottom: 5px; }
 .ui-panel select, .ui-panel button { background-color: #333; color: white; border: 1px solid #555; cursor: pointer; }
 .ui-panel button:hover { background-color: #45a049; }
+.panel-section { display: flex; flex-direction: column; gap: 8px; }
+.panel-section + .panel-section { margin-top: 12px; padding-top: 12px; border-top: 1px solid #555; }
+.panel-section--submenu:empty { display: none; }
+#visual-panel .panel-section label, #visual-panel .panel-section select,
+#exercise-panel .panel-section label, #exercise-panel .panel-section select { margin-bottom: 0; }
 #visual-panel { top: 10px; left: 10px; width: 280px; }
 #controls {
     bottom: 0;
@@ -40,8 +45,6 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; }
 .speed-display .arrow-icon { font-size: 1.5em; }
 #horizontal-speed-value, #vertical-speed-value { font-size: 1.8em; font-weight: bold; color: #66d9ef; min-width: 30px; text-align: center; }
 #exercise-panel { top: 10px; right: 10px; width: 280px; }
-#exercise-panel > div { margin-bottom: 15px; }
-#exercise-submenu { margin-top: 10px; padding-top: 10px; border-top: 1px solid #555; min-height: 50px; }
 .submenu-item { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
 .submenu-item label { font-size: 1em; width: auto; margin-bottom: 0; }
 .submenu-item input[type="checkbox"] { width: 20px; height: 20px; }


### PR DESCRIPTION
## Summary
- add a Stroop Test submenu slider to scale the displayed word between 80% and 300%
- refresh the app version metadata and cache key to 0.65

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d24b05ca1483238ed2de3d04400d2f