### PR TITLE
feat: add Stroop word size control and bump to v0.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.66 (2025-10-01)
+
+* Ajout d'un réglage de taille du mot dans le Stroop Test pour adapter l'exercice à l'utilisateur.
+* Passage de la version affichée et du cache applicatif en 0.66.
+
 ## v0.64 (2025-09-24)
 
 * Harmonisation visuelle des panneaux « Stimulation » et « Exercice » pour une présentation cohérente.

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.64</title>
+    <title>OW v0.66</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.64">
+    <link rel="stylesheet" href="styles.css?v=0.66">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.64</div>
+        <div id="version-display">v0.66</div>
     <div id="vr-message">Regardez la scène dans Steam VR</div>
 
     <div id="visual-panel" class="ui-panel">
@@ -97,7 +97,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.64"></script>
+    <script type="module" src="main.js?v=0.66"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/modules/stroop.js
+++ b/modules/stroop.js
@@ -1,4 +1,8 @@
 
+const DEFAULT_WORD_WIDTH = 6;
+const MIN_WORD_WIDTH = 5;
+const MAX_WORD_WIDTH = 18;
+
 const stroopWords = [
     { word: 'ROUGE', color: '#FF0000' },
     { word: 'VERT', color: '#00FF00' },
@@ -50,13 +54,18 @@ export const exerciseModule = {
                 <input type="range" id="stroop-speed-slider" min="1" max="5" value="2" step="0.5">
                 <span id="stroop-speed-value">2s</span>
             </div>
+            <div>
+                <label for="stroop-size-slider">Taille du mot</label>
+                <input type="range" id="stroop-size-slider" min="${MIN_WORD_WIDTH}" max="${MAX_WORD_WIDTH}" value="${DEFAULT_WORD_WIDTH}" step="0.5">
+                <span id="stroop-size-value">100%</span>
+            </div>
         `;
 
         // Create text element
         textElement = document.createElement('a-text');
         textElement.setAttribute('id', 'stroop-text');
         textElement.setAttribute('align', 'center');
-        textElement.setAttribute('width', '6');
+        textElement.setAttribute('width', DEFAULT_WORD_WIDTH);
         rig.appendChild(textElement);
 
         positionElement();
@@ -66,14 +75,30 @@ export const exerciseModule = {
         let speed = 2000;
         stroopInterval = setInterval(updateStroop, speed);
 
-        // Event listener for slider
+        // Event listeners for submenu controls
         const speedSlider = document.getElementById('stroop-speed-slider');
         const speedValue = document.getElementById('stroop-speed-value');
+        const sizeSlider = document.getElementById('stroop-size-slider');
+        const sizeValue = document.getElementById('stroop-size-value');
+
+        const updateSize = (width) => {
+            textElement.setAttribute('width', width);
+            const percentage = Math.round((width / DEFAULT_WORD_WIDTH) * 100);
+            sizeValue.textContent = `${percentage}%`;
+        };
+
+        updateSize(DEFAULT_WORD_WIDTH);
+
         speedSlider.addEventListener('input', (event) => {
             speed = event.target.value * 1000;
             speedValue.textContent = `${event.target.value}s`;
             clearInterval(stroopInterval);
             stroopInterval = setInterval(updateStroop, speed);
+        });
+
+        sizeSlider.addEventListener('input', (event) => {
+            const newWidth = parseFloat(event.target.value);
+            updateSize(newWidth);
         });
     },
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const CACHE_NAME = 'opto-vr-cache-v0.64';
+const CACHE_NAME = 'opto-vr-cache-v0.66';
 const URLS_TO_CACHE = [
   'index.html',
   'styles.css',


### PR DESCRIPTION
## Summary
- add configurable word size slider to the Stroop Test exercise submenu
- default Stroop word size preserved while allowing reduction and enlargement up to 3x
- bump displayed app version and cache identifier to v0.66 and document the change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d25ba3648083239f2dc783b49278f5