### PR TITLE
Add FPS overlay for VR scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,16 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.64</title>
+    <title>OW v0.67</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.64">
+    <link rel="stylesheet" href="styles.css?v=0.67">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.64</div>
+        <div id="version-display">v0.67</div>
+        <div id="fps-display">-- fps</div>
     <div id="vr-message">Regardez la scène dans Steam VR</div>
 
     <div id="visual-panel" class="ui-panel">
@@ -78,7 +79,7 @@
         <div id="exercise-submenu" class="panel-section panel-section--submenu"></div>
     </div>
 
-    <a-scene id="scene" exercise-ticker fog="type: linear; color: #111; near: 5; far: 200">
+    <a-scene id="scene" exercise-ticker fps-counter fog="type: linear; color: #111; near: 5; far: 200">
 
         <a-assets>
             <!-- Assets restants (si nécessaire pour d'autres modules) -->
@@ -97,7 +98,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.64"></script>
+    <script type="module" src="main.js?v=0.67"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/main.js
+++ b/main.js
@@ -22,6 +22,33 @@ AFRAME.registerComponent('exercise-ticker', {
     }
 });
 
+AFRAME.registerComponent('fps-counter', {
+    schema: { interval: { type: 'number', default: 500 } },
+    init: function () {
+        this.elapsed = 0;
+        this.frames = 0;
+        this.fpsDisplayEl = document.getElementById('fps-display');
+    },
+    tick: function (time, timeDelta) {
+        if (!this.fpsDisplayEl) {
+            this.fpsDisplayEl = document.getElementById('fps-display');
+            if (!this.fpsDisplayEl) {
+                return;
+            }
+        }
+
+        this.elapsed += timeDelta;
+        this.frames += 1;
+
+        if (this.elapsed >= this.data.interval) {
+            const fps = (this.frames * 1000) / this.elapsed;
+            this.fpsDisplayEl.textContent = `${Math.round(fps)} fps`;
+            this.elapsed = 0;
+            this.frames = 0;
+        }
+    }
+});
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- DOM Elements ---
     const sceneEl = document.querySelector('a-scene');

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,20 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; }
 .submenu-item label { font-size: 1em; width: auto; margin-bottom: 0; }
 .submenu-item input[type="checkbox"] { width: 20px; height: 20px; }
 #version-display { position: absolute; bottom: 10px; left: 10px; color: white; font-size: 0.8em; z-index: 11; opacity: 0.5; user-select: none; }
+#fps-display {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    color: #8bc34a;
+    font-size: 0.75em;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 4px 8px;
+    border-radius: 4px;
+    z-index: 12;
+    pointer-events: none;
+    user-select: none;
+}
 #vr-message { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background: rgba(0,0,0,0.7); padding: 20px; border-radius: 10px; z-index: 20; font-size: 2em; color: white; text-align: center; display: none; user-select: none; pointer-events: none; }
 a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: none; }
 


### PR DESCRIPTION
## Summary
- update the application version markers to 0.67 and expose a new FPS HUD element in the DOM
- style the FPS counter so it appears unobtrusively in the bottom-right corner across devices
- register an A-Frame component that samples frame timing and updates the HUD for VR and non-VR views

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d25e2ea0f08323a798c2070e207e32