### PR TITLE
chore: update version display and reset heights sky

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.68</title>
+    <title>OW v0.69</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.68">
+    <link rel="stylesheet" href="styles.css?v=0.69">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.68</div>
+        <div id="version-display">v0.69</div>
     <div id="vr-message">Regardez la scène dans Steam VR</div>
 
     <div id="visual-panel" class="ui-panel">
@@ -53,16 +53,20 @@
                 <div class="control-item optokinetic-control">
                     <div class="speed-display speed-display--stacked" role="group" aria-label="Vitesse horizontale">
                         <span class="sr-only">Vitesse horizontale</span>
-                        <span id="horizontal-speed-value" class="speed-value">0</span>
-                        <span class="speed-unit">deg/s</span>
+                        <span class="speed-value-row">
+                            <span id="horizontal-speed-value" class="speed-value">0</span>
+                            <span class="speed-unit">deg/s</span>
+                        </span>
                         <span class="arrow-icon" aria-hidden="true">↔</span>
                     </div>
                 </div>
                 <div class="control-item optokinetic-control">
                     <div class="speed-display speed-display--stacked" role="group" aria-label="Vitesse verticale">
                         <span class="sr-only">Vitesse verticale</span>
-                        <span id="vertical-speed-value" class="speed-value">0</span>
-                        <span class="speed-unit">deg/s</span>
+                        <span class="speed-value-row">
+                            <span id="vertical-speed-value" class="speed-value">0</span>
+                            <span class="speed-unit">deg/s</span>
+                        </span>
                         <span class="arrow-icon" aria-hidden="true">↕</span>
                     </div>
                 </div>
@@ -137,7 +141,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.68"></script>
+    <script type="module" src="main.js?v=0.69"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,11 @@ body {
     align-items: flex-start;
     gap: 4px;
 }
+.speed-value-row {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+}
 .speed-display--stacked .arrow-icon {
     font-size: 1.6em;
     line-height: 1;
@@ -227,7 +232,7 @@ body {
     position: absolute;
     bottom: 20px;
     left: 20px;
-    color: rgba(31, 45, 61, 0.75);
+    color: #ffffff;
     font-weight: 600;
     font-size: 0.9em;
     z-index: 11;

--- a/visuals/heights.js
+++ b/visuals/heights.js
@@ -8,7 +8,6 @@ import { heightsDecorModule } from './decor_heights.js';
 let sceneEl, rigEl;
 let platformEl;
 let skyEl;
-let originalSkyColor = null;
 let animationFrameId;
 let actualSpeed = 0;
 let targetSpeed = 0;
@@ -157,7 +156,6 @@ export const heightsModule = {
 
         skyEl = sceneEl.querySelector('#sky');
         if (skyEl) {
-            originalSkyColor = skyEl.getAttribute('color');
             skyEl.setAttribute('color', '#8dc6ff');
         }
 
@@ -200,11 +198,10 @@ export const heightsModule = {
         if(rigEl) {
             rigEl.object3D.position.y = 0;
         }
-        if (skyEl && originalSkyColor !== null) {
-            skyEl.setAttribute('color', originalSkyColor);
+        if (skyEl) {
+            skyEl.setAttribute('color', '#000000');
         }
         skyEl = null;
-        originalSkyColor = null;
     },
 
     regenerate() {


### PR DESCRIPTION
## Summary
- bump the UI assets to version 0.69 and update the on-screen version badge styling
- keep the optokinetic speed units inline with their values for clarity
- force the heights module to restore the neutral black sky when it is closed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2b47cce148323b04be24242166342