### PR TITLE
Clone fog settings for heights decor

### DIFF
--- a/visuals/decor_heights.js
+++ b/visuals/decor_heights.js
@@ -16,7 +16,9 @@ export const heightsDecorModule = {
         }
 
         this.sceneEl = sceneEl;
-        this.originalFog = sceneEl.getAttribute('fog');
+
+        const currentFog = sceneEl.getAttribute('fog');
+        this.originalFog = currentFog ? { ...currentFog } : null;
 
         this.decorRoot = document.createElement('a-entity');
         this.decorRoot.setAttribute('id', 'heights-decor-root');


### PR DESCRIPTION
## Summary
- clone the fog settings when initializing the heights decor to preserve the original configuration
- restore the cloned fog settings on cleanup or remove the fog attribute when none existed so the scene returns to its default appearance

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2dd5fe5c8832397ffc91fcb2b02eb