### PR TITLE
Adjust mobile panel spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -408,3 +408,16 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     white-space: nowrap;
     border: 0;
 }
+
+@media (max-width: 768px) {
+    #visual-panel {
+        max-height: clamp(160px, 45vh, 280px);
+    }
+
+    body::after {
+        content: "";
+        display: block;
+        height: clamp(140px, 40vh, 260px);
+        pointer-events: none;
+    }
+}


### PR DESCRIPTION
## Summary
- limit the visual panel height on small screens to keep controls reachable
- extend mobile scroll space with a body pseudo-element so the exercise panel can move higher

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d38e5538cc832391beed52d8748e32