### PR TITLE
Scope service worker cache per channel

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,8 @@
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/service-worker.js').then(registration => {
+                const swUrl = new URL('service-worker.js', window.location.href);
+                navigator.serviceWorker.register(swUrl.href).then(registration => {
                     console.log('ServiceWorker registration successful with scope: ', registration.scope);
                 }, err => {
                     console.log('ServiceWorker registration failed: ', err);

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.73</title>
+    <title>OW v0.75</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.73">
+    <link rel="stylesheet" href="styles.css?v=0.75">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.73</div>
+        <div id="version-display">v0.75</div>
 
     <div class="ui-panels-container">
         <div id="visual-panel" class="ui-panel">
@@ -143,7 +143,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.73"></script>
+    <script type="module" src="main.js?v=0.75"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.73';
+const VERSION = '0.75';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,10 @@
 
-const CACHE_NAME = 'opto-vr-cache-v0.73';
+const VERSION = '0.73';
+const scopePath = new URL(self.registration.scope).pathname;
+const normalizedPath = scopePath.replace(/\/+$/, '');
+const pathSegments = normalizedPath.split('/').filter(Boolean);
+const channel = pathSegments[pathSegments.length - 1] || 'root';
+const CACHE_NAME = `opto-vr-${channel}-v${VERSION}`;
 const URLS_TO_CACHE = [
   'index.html',
   'styles.css',

--- a/versions/v0.73/index.html
+++ b/versions/v0.73/index.html
@@ -147,7 +147,8 @@
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/service-worker.js').then(registration => {
+                const swUrl = new URL('service-worker.js', window.location.href);
+                navigator.serviceWorker.register(swUrl.href).then(registration => {
                     console.log('ServiceWorker registration successful with scope: ', registration.scope);
                 }, err => {
                     console.log('ServiceWorker registration failed: ', err);

--- a/versions/v0.73/service-worker.js
+++ b/versions/v0.73/service-worker.js
@@ -1,5 +1,10 @@
 
-const CACHE_NAME = 'opto-vr-cache-v0.73';
+const VERSION = '0.73';
+const scopePath = new URL(self.registration.scope).pathname;
+const normalizedPath = scopePath.replace(/\/+$/, '');
+const pathSegments = normalizedPath.split('/').filter(Boolean);
+const channel = pathSegments[pathSegments.length - 1] || 'root';
+const CACHE_NAME = `opto-vr-${channel}-v${VERSION}`;
 const URLS_TO_CACHE = [
   'index.html',
   'styles.css',


### PR DESCRIPTION
## Summary
- derive the service worker cache identifier from the registration scope and version so each channel keeps its own cache
- register the service worker using a URL resolved from the current page to avoid cross-branch scopes
- mirror the same updates in the archived v0.73 build for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94ba610e883238a71cff4099c7ff9