### PR TITLE
Add mobile tabs for configuration panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,108 +14,118 @@
 
         <div id="version-display">v0.76</div>
 
-    <div class="ui-panels-container">
-        <div id="visual-panel" class="ui-panel">
-            <div class="panel-section panel-section--header">
-                <label for="visual-select">Stimulation</label>
-                <select id="visual-select">
-                    <option value="none">Aucune</option>
-                    <option value="optokinetic" selected>Optocinétique</option>
-                    <option value="opticalFlow">Flux Optique</option>
-                    <option value="rotatingCube">Cube Rotatif</option>
-                    <option value="heights">Hauteurs</option>
-                </select>
-            </div>
-            <div id="visual-submenu" class="panel-section panel-section--submenu">
-                <!-- Panneau de contrôle pour l'Optocinétique -->
-                <div id="optokinetic-controls" class="control-group">
-                    <div id="ambiance-control" class="control-item">
-                        <label for="palette-select">Ambiance</label>
-                        <select id="palette-select">
-                            <option value="default">Défaut (Blanc)</option>
-                            <option value="none">Aucun (Noir)</option>
-                            <option value="forest">Forêt Mystique</option>
-                            <option value="sunset">Coucher de Soleil</option>
-                            <option value="ocean">Océan Profond</option>
-                            <option value="retro">Néon Rétro</option>
-                            <option value="pastel">Tons Pastel</option>
-                            <option value="autumn">Épices d'Automne</option>
-                            <option value="aurora">Aurore Boréale</option>
-                            <option value="volcanic">Volcanique</option>
-                            <option value="cyberpunk">Cyberpunk</option>
-                            <option value="auto">Changement Automatique</option>
-                        </select>
-                    </div>
-                    <div class="control-item optokinetic-control">
-                        <label for="density-slider">Densité</label>
-                        <input type="range" id="density-slider" min="50" max="200" value="100">
-                    </div>
-                    <div class="control-item optokinetic-control">
-                        <div class="speed-display speed-display--stacked" role="group" aria-label="Vitesse horizontale">
-                            <span class="sr-only">Vitesse horizontale</span>
-                            <span class="speed-value-row">
-                                <span id="horizontal-speed-value" class="speed-value">0</span>
-                                <span class="speed-unit">deg/s</span>
-                            </span>
-                            <span class="arrow-icon" aria-hidden="true">↔</span>
-                        </div>
-                    </div>
-                    <div class="control-item optokinetic-control">
-                        <div class="speed-display speed-display--stacked" role="group" aria-label="Vitesse verticale">
-                            <span class="sr-only">Vitesse verticale</span>
-                            <span class="speed-value-row">
-                                <span id="vertical-speed-value" class="speed-value">0</span>
-                                <span class="speed-unit">deg/s</span>
-                            </span>
-                            <span class="arrow-icon" aria-hidden="true">↕</span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Panneau de contrôle pour le Flux Optique -->
-                <div id="optical-flow-controls" class="control-group" style="display: none;">
-                    <div class="control-item optical-flow-control">
-                        <label>Vitesse</label>
-                        <div class="speed-display">
-                            <span class="arrow-icon">↕</span>
-                            <span id="translation-speed-value">0.0</span>
-                            <span>m/s</span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Panneau de contrôle pour le Cube Rotatif -->
-                <div id="rotating-cube-controls" class="control-group" style="display: none;">
-                    <div class="control-item rotating-cube-control">
-                        <label for="cube-speed-slider">Vitesse Rotation</label>
-                        <input type="range" id="cube-speed-slider" min="0" max="5" value="0.5" step="0.1">
-                        <span id="cube-speed-value">0.5</span>
-                    </div>
-                </div>
-
-                <!-- Panneau de contrôle pour les Hauteurs -->
-                <div id="heights-controls" class="control-group">
-                    <div class="control-row">
-                        <span class="control-row-label">Vitesse</span>
-                        <span id="height-speed-value">0.0</span>
-                        <span class="control-row-unit">m/s</span>
-                    </div>
-                    <p class="instructions">Utilisez les flèches HAUT/BAS pour monter/descendre et ESPACE pour arrêter.</p>
-                </div>
-            </div>
+    <div class="ui-panels-container has-mobile-tabs">
+        <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
+            <button type="button" id="tab-visual" class="mobile-tabbutton" role="tab" aria-controls="visual-panel" aria-selected="true" data-target="visual-panel">
+                Stimulation
+            </button>
+            <button type="button" id="tab-exercise" class="mobile-tabbutton" role="tab" aria-controls="exercise-panel" aria-selected="false" data-target="exercise-panel">
+                Exercice
+            </button>
         </div>
+        <div class="mobile-tabpanes">
+            <div id="visual-panel" class="ui-panel" role="tabpanel" tabindex="0" aria-labelledby="tab-visual">
+                <div class="panel-section panel-section--header">
+                    <label for="visual-select">Stimulation</label>
+                    <select id="visual-select">
+                        <option value="none">Aucune</option>
+                        <option value="optokinetic" selected>Optocinétique</option>
+                        <option value="opticalFlow">Flux Optique</option>
+                        <option value="rotatingCube">Cube Rotatif</option>
+                        <option value="heights">Hauteurs</option>
+                    </select>
+                </div>
+                <div id="visual-submenu" class="panel-section panel-section--submenu">
+                    <!-- Panneau de contrôle pour l'Optocinétique -->
+                    <div id="optokinetic-controls" class="control-group">
+                        <div id="ambiance-control" class="control-item">
+                            <label for="palette-select">Ambiance</label>
+                            <select id="palette-select">
+                                <option value="default">Défaut (Blanc)</option>
+                                <option value="none">Aucun (Noir)</option>
+                                <option value="forest">Forêt Mystique</option>
+                                <option value="sunset">Coucher de Soleil</option>
+                                <option value="ocean">Océan Profond</option>
+                                <option value="retro">Néon Rétro</option>
+                                <option value="pastel">Tons Pastel</option>
+                                <option value="autumn">Épices d'Automne</option>
+                                <option value="aurora">Aurore Boréale</option>
+                                <option value="volcanic">Volcanique</option>
+                                <option value="cyberpunk">Cyberpunk</option>
+                                <option value="auto">Changement Automatique</option>
+                            </select>
+                        </div>
+                        <div class="control-item optokinetic-control">
+                            <label for="density-slider">Densité</label>
+                            <input type="range" id="density-slider" min="50" max="200" value="100">
+                        </div>
+                        <div class="control-item optokinetic-control">
+                            <div class="speed-display speed-display--stacked" role="group" aria-label="Vitesse horizontale">
+                                <span class="sr-only">Vitesse horizontale</span>
+                                <span class="speed-value-row">
+                                    <span id="horizontal-speed-value" class="speed-value">0</span>
+                                    <span class="speed-unit">deg/s</span>
+                                </span>
+                                <span class="arrow-icon" aria-hidden="true">↔</span>
+                            </div>
+                        </div>
+                        <div class="control-item optokinetic-control">
+                            <div class="speed-display speed-display--stacked" role="group" aria-label="Vitesse verticale">
+                                <span class="sr-only">Vitesse verticale</span>
+                                <span class="speed-value-row">
+                                    <span id="vertical-speed-value" class="speed-value">0</span>
+                                    <span class="speed-unit">deg/s</span>
+                                </span>
+                                <span class="arrow-icon" aria-hidden="true">↕</span>
+                            </div>
+                        </div>
+                    </div>
 
-        <div id="exercise-panel" class="ui-panel">
-            <div class="panel-section panel-section--header">
-                <label for="exercise-select">Exercice</label>
-                <select id="exercise-select">
-                    <option value="none" selected>Aucun</option>
-                    <option value="targetPointer">Cible &amp; Pointeur</option>
-                    <option value="goNoGo">Go / No-Go</option>
-                    <option value="stroop">Stroop Test</option>
-                </select>
+                    <!-- Panneau de contrôle pour le Flux Optique -->
+                    <div id="optical-flow-controls" class="control-group" style="display: none;">
+                        <div class="control-item optical-flow-control">
+                            <label>Vitesse</label>
+                            <div class="speed-display">
+                                <span class="arrow-icon">↕</span>
+                                <span id="translation-speed-value">0.0</span>
+                                <span>m/s</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Panneau de contrôle pour le Cube Rotatif -->
+                    <div id="rotating-cube-controls" class="control-group" style="display: none;">
+                        <div class="control-item rotating-cube-control">
+                            <label for="cube-speed-slider">Vitesse Rotation</label>
+                            <input type="range" id="cube-speed-slider" min="0" max="5" value="0.5" step="0.1">
+                            <span id="cube-speed-value">0.5</span>
+                        </div>
+                    </div>
+
+                    <!-- Panneau de contrôle pour les Hauteurs -->
+                    <div id="heights-controls" class="control-group">
+                        <div class="control-row">
+                            <span class="control-row-label">Vitesse</span>
+                            <span id="height-speed-value">0.0</span>
+                            <span class="control-row-unit">m/s</span>
+                        </div>
+                        <p class="instructions">Utilisez les flèches HAUT/BAS pour monter/descendre et ESPACE pour arrêter.</p>
+                    </div>
+                </div>
             </div>
-            <div id="exercise-submenu" class="panel-section panel-section--submenu"></div>
+
+            <div id="exercise-panel" class="ui-panel" role="tabpanel" tabindex="0" aria-labelledby="tab-exercise">
+                <div class="panel-section panel-section--header">
+                    <label for="exercise-select">Exercice</label>
+                    <select id="exercise-select">
+                        <option value="none" selected>Aucun</option>
+                        <option value="targetPointer">Cible &amp; Pointeur</option>
+                        <option value="goNoGo">Go / No-Go</option>
+                        <option value="stroop">Stroop Test</option>
+                    </select>
+                </div>
+                <div id="exercise-submenu" class="panel-section panel-section--submenu"></div>
+            </div>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.76</title>
+    <title>OW v0.77</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.76">
+    <link rel="stylesheet" href="styles.css?v=0.77">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.76</div>
+        <div id="version-display">v0.77</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -135,6 +135,14 @@
 
     <div id="controls" class="ui-panel ui-panel--floating">
         <button id="recenter-button">Recentrer (R)</button>
+        <div id="mobile-keypad" class="mobile-keypad" role="group" aria-label="Raccourcis tactiles">
+            <button type="button" class="icon-button mobile-keypad-button" data-key="arrowleft" aria-label="Flèche gauche">←</button>
+            <button type="button" class="icon-button mobile-keypad-button" data-key="arrowup" aria-label="Flèche haut">↑</button>
+            <button type="button" class="icon-button mobile-keypad-button" data-key="arrowright" aria-label="Flèche droite">→</button>
+            <button type="button" class="icon-button mobile-keypad-button" data-key="space" aria-label="Barre espace">⎵</button>
+            <button type="button" class="icon-button mobile-keypad-button" data-key="arrowdown" aria-label="Flèche bas">↓</button>
+            <button type="button" class="icon-button mobile-keypad-button" data-key="i" aria-label="Lettre I">I</button>
+        </div>
         <button id="shortcut-button" class="icon-button" aria-haspopup="dialog" aria-expanded="false" aria-controls="shortcut-overlay" title="Raccourcis clavier">?</button>
         <div id="vr-message">Regardez la scène dans SteamVR</div>
     </div>
@@ -177,7 +185,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.76"></script>
+    <script type="module" src="main.js?v=0.77"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
             <button type="button" id="tab-exercise" class="mobile-tabbutton" role="tab" aria-controls="exercise-panel" aria-selected="false" data-target="exercise-panel">
                 Exercice
             </button>
+            <button type="button" id="mobile-panels-toggle" class="mobile-tabbutton mobile-tabbutton--toggle" aria-pressed="false">
+                <span class="mobile-tabbutton-label">Masquer</span>
+                <span class="sr-only"> les menus</span>
+            </button>
         </div>
         <div class="mobile-tabpanes">
             <div id="visual-panel" class="ui-panel" role="tabpanel" tabindex="0" aria-labelledby="tab-visual">

--- a/main.js
+++ b/main.js
@@ -52,6 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const mobileTabButtons = mobileTabbar ? Array.from(mobileTabbar.querySelectorAll('[role="tab"]')) : [];
     const mobilePanelsToggle = document.getElementById('mobile-panels-toggle');
     const mobilePanelsToggleLabel = mobilePanelsToggle ? mobilePanelsToggle.querySelector('.mobile-tabbutton-label') : null;
+    const mobileKeypad = document.getElementById('mobile-keypad');
     let mobilePanelsHandle = null;
     let areMobilePanelsHidden = false;
     const mobilePanels = {
@@ -518,8 +519,22 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('touchend', blurActiveRange);
     document.addEventListener('mouseup', blurActiveRange);
 
-    document.addEventListener('keydown', (e) => {
-        const key = e.key.toLowerCase();
+    const normalizeInputKey = (value) => {
+        if (!value) {
+            return '';
+        }
+        if (value === ' ' || value.toLowerCase() === 'space' || value.toLowerCase() === 'spacebar') {
+            return ' ';
+        }
+        return value.toLowerCase();
+    };
+
+    const handleControlInput = (inputValue) => {
+        const key = normalizeInputKey(inputValue);
+
+        if (!key) {
+            return;
+        }
 
         if (isShortcutOverlayOpen()) {
             if (key === 'escape') {
@@ -550,6 +565,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         newSpeeds.v = -newSpeeds.v;
                         speedUpdated = true;
                         break;
+                    default:
+                        break;
                 }
             } else if (moduleName === 'opticalFlow') {
                 switch (key) {
@@ -560,6 +577,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         newSpeeds.t = -newSpeeds.t;
                         speedUpdated = true;
                         break;
+                    default:
+                        break;
                 }
             } else if (moduleName === 'heights') {
                 if (key === 'arrowup') {
@@ -568,7 +587,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 } else if (key === 'arrowdown') {
                     newSpeeds.y = Math.max(-5, newSpeeds.y - 0.5);
                     speedUpdated = true;
-                } else if (key === ' ') { // Espace
+                } else if (key === ' ') {
                     newSpeeds.y = 0;
                     speedUpdated = true;
                 }
@@ -583,11 +602,31 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         }
 
-        // Exercise module controls
         if (activeExerciseModule && typeof activeExerciseModule.handleKey === 'function') {
             activeExerciseModule.handleKey(key);
         }
+    };
+
+    document.addEventListener('keydown', (event) => {
+        handleControlInput(event.key);
     });
+
+    if (mobileKeypad) {
+        mobileKeypad.addEventListener('click', (event) => {
+            const button = event.target.closest('.mobile-keypad-button');
+            if (!button) {
+                return;
+            }
+
+            const datasetKey = button.dataset.key;
+            if (!datasetKey) {
+                return;
+            }
+
+            handleControlInput(datasetKey);
+            button.blur();
+        });
+    }
 
     sceneEl.addEventListener('enter-vr', () => {
         vrMessage.style.display = 'flex';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.76';
+const VERSION = '0.77';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/styles.css
+++ b/styles.css
@@ -545,6 +545,16 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+.mobile-tabbutton--toggle {
+    font-size: 0.9em;
+    padding-inline: 14px;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+}
+
 .mobile-tabbutton:hover {
     background: rgba(255, 255, 255, 0.92);
     border-color: rgba(42, 161, 152, 0.5);
@@ -566,6 +576,37 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     display: contents;
 }
 
+.mobile-panels-handle {
+    position: fixed;
+    top: clamp(12px, 6vh, 24px);
+    right: clamp(12px, 6vw, 20px);
+    z-index: 18;
+    border-radius: 999px;
+    padding: 12px 18px;
+    font-weight: 600;
+    font-size: 0.95em;
+    background: rgba(42, 161, 152, 0.92);
+    color: #ffffff;
+    border: 1px solid rgba(17, 102, 96, 0.65);
+    box-shadow: 0 14px 32px rgba(17, 102, 96, 0.26);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.mobile-panels-handle:hover {
+    background: rgba(36, 138, 130, 0.98);
+    box-shadow: 0 18px 36px rgba(17, 102, 96, 0.3);
+}
+
+.mobile-panels-handle:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35), 0 0 0 6px rgba(42, 161, 152, 0.65);
+}
+
 @media (max-width: 768px) {
     .ui-panels-container {
         position: fixed;
@@ -577,13 +618,14 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         flex-direction: column;
         justify-content: flex-start;
         align-items: stretch;
-        width: min(100%, 380px);
+        width: min(92vw, 320px);
+        max-width: 320px;
         padding-inline: clamp(8px, 4vw, 16px);
         padding-top: calc(env(safe-area-inset-top) + clamp(12px, 4vh, 24px));
         padding-bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 4vh, 24px));
         gap: clamp(16px, 6vh, 28px);
         min-height: 100vh;
-        overflow-y: auto;
+        overflow-y: visible;
         touch-action: pan-y;
         z-index: 12;
     }
@@ -613,13 +655,14 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     }
 
     .ui-panels-container.is-mobile-tabs {
-        overflow-y: hidden;
+        overflow-y: visible;
         gap: clamp(12px, 4vh, 24px);
+        transition: opacity 0.25s ease, visibility 0.25s ease, transform 0.25s ease;
     }
 
     .ui-panels-container.is-mobile-tabs .mobile-tabbar {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
         gap: 8px;
         padding: 8px;
         background: rgba(255, 255, 255, 0.8);
@@ -632,6 +675,7 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     .ui-panels-container.is-mobile-tabs .mobile-tabpanes {
         display: flex;
         flex: 1 1 auto;
+        min-height: 0;
     }
 
     .ui-panels-container.is-mobile-tabs .mobile-tabpanes .ui-panel {
@@ -646,10 +690,27 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         flex-direction: column;
         pointer-events: auto;
         opacity: 1;
+        max-height: calc(100vh - clamp(168px, 32vh, 240px));
+        overflow-y: auto;
+    }
+
+    .ui-panels-container.is-mobile-tabs.is-mobile-hidden {
+        opacity: 0;
+        visibility: hidden;
+        transform: translate(-50%, -24px) scale(0.98);
+        pointer-events: none;
     }
 
     #visual-panel,
     #exercise-panel {
         width: 100%;
+    }
+
+    .mobile-panels-handle {
+        display: inline-flex;
+    }
+
+    .mobile-panels-handle[hidden] {
+        display: none;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,7 @@ body {
     margin: 0;
     min-height: 100vh;
 }
-.ui-panel {
+.ui-panel { 
     position: absolute;
     background: #ffffff;
     padding: 20px;
@@ -528,6 +528,44 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     border: 0;
 }
 
+.mobile-tabbar {
+    display: none;
+}
+
+.mobile-tabbutton {
+    appearance: none;
+    border: 1px solid rgba(42, 161, 152, 0.32);
+    background: rgba(255, 255, 255, 0.72);
+    color: #184b46;
+    font-weight: 600;
+    font-size: 0.95em;
+    padding: 10px 16px;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.mobile-tabbutton:hover {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: rgba(42, 161, 152, 0.5);
+}
+
+.mobile-tabbutton.is-active {
+    background: #2aa198;
+    color: #ffffff;
+    border-color: #2aa198;
+    box-shadow: 0 10px 24px rgba(42, 161, 152, 0.28);
+}
+
+.mobile-tabbutton:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(42, 161, 152, 0.28);
+}
+
+.mobile-tabpanes {
+    display: contents;
+}
+
 @media (max-width: 768px) {
     .ui-panels-container {
         position: fixed;
@@ -537,17 +575,23 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         transform: translateX(-50%);
         display: flex;
         flex-direction: column;
-        justify-content: space-between;
+        justify-content: flex-start;
         align-items: stretch;
         width: min(100%, 380px);
         padding-inline: clamp(8px, 4vw, 16px);
         padding-top: calc(env(safe-area-inset-top) + clamp(12px, 4vh, 24px));
         padding-bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 4vh, 24px));
-        gap: clamp(32px, 15vh, 120px);
+        gap: clamp(16px, 6vh, 28px);
         min-height: 100vh;
-        overflow: hidden;
+        overflow-y: auto;
         touch-action: pan-y;
         z-index: 12;
+    }
+
+    .mobile-tabpanes {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(12px, 4vh, 20px);
     }
 
     .ui-panels-container .ui-panel {
@@ -556,11 +600,52 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         right: auto;
         top: auto;
         width: 100%;
-        max-height: clamp(140px, 35vh, 260px);
+        max-height: none;
         flex: 0 0 auto;
         overflow-y: auto;
         overscroll-behavior: contain;
         -webkit-overflow-scrolling: touch;
+    }
+
+    .ui-panels-container .ui-panel:focus-visible {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba(42, 161, 152, 0.28);
+    }
+
+    .ui-panels-container.is-mobile-tabs {
+        overflow-y: hidden;
+        gap: clamp(12px, 4vh, 24px);
+    }
+
+    .ui-panels-container.is-mobile-tabs .mobile-tabbar {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+        padding: 8px;
+        background: rgba(255, 255, 255, 0.8);
+        border-radius: 18px;
+        border: 1px solid rgba(42, 161, 152, 0.18);
+        box-shadow: 0 12px 24px rgba(15, 50, 60, 0.16);
+        backdrop-filter: blur(6px);
+    }
+
+    .ui-panels-container.is-mobile-tabs .mobile-tabpanes {
+        display: flex;
+        flex: 1 1 auto;
+    }
+
+    .ui-panels-container.is-mobile-tabs .mobile-tabpanes .ui-panel {
+        display: none;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 0.2s ease;
+    }
+
+    .ui-panels-container.is-mobile-tabs .mobile-tabpanes .ui-panel.is-active-mobile {
+        display: flex;
+        flex-direction: column;
+        pointer-events: auto;
+        opacity: 1;
     }
 
     #visual-panel,

--- a/styles.css
+++ b/styles.css
@@ -565,6 +565,9 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     font-size: 0.95em;
     padding: 10px 16px;
     border-radius: 12px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
     transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     min-width: 0;
@@ -638,15 +641,17 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         position: fixed;
         top: 0;
         bottom: 0;
-        left: 50%;
-        transform: translateX(-50%);
+        left: 0;
+        right: 0;
+        transform: none;
+        margin: 0 auto;
         display: flex;
         flex-direction: column;
         justify-content: flex-start;
         align-items: stretch;
-        width: min(90vw, 300px);
-        max-width: 300px;
-        padding-inline: clamp(8px, 4vw, 16px);
+        width: min(100%, 360px);
+        max-width: 360px;
+        padding-inline: clamp(8px, 3vw, 14px);
         padding-top: calc(env(safe-area-inset-top) + clamp(12px, 4vh, 24px));
         padding-bottom: calc(env(safe-area-inset-bottom) + clamp(96px, 18vh, 140px));
         gap: clamp(16px, 6vh, 28px);
@@ -688,14 +693,24 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
 
     .ui-panels-container.is-mobile-tabs .mobile-tabbar {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr)) auto;
-        gap: 8px;
-        padding: 8px;
-        background: rgba(255, 255, 255, 0.8);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-auto-rows: minmax(0, auto);
+        gap: 10px;
+        padding: 10px;
+        background: rgba(255, 255, 255, 0.85);
         border-radius: 18px;
         border: 1px solid rgba(42, 161, 152, 0.18);
         box-shadow: 0 12px 24px rgba(15, 50, 60, 0.16);
         backdrop-filter: blur(6px);
+    }
+
+    .ui-panels-container.is-mobile-tabs .mobile-tabbar .mobile-tabbutton {
+        width: 100%;
+    }
+
+    .ui-panels-container.is-mobile-tabs .mobile-tabbar .mobile-tabbutton--toggle {
+        grid-column: 1 / -1;
+        justify-self: stretch;
     }
 
     .ui-panels-container.is-mobile-tabs .mobile-tabpanes {
@@ -723,7 +738,7 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     .ui-panels-container.is-mobile-tabs.is-mobile-hidden {
         opacity: 0;
         visibility: hidden;
-        transform: translate(-50%, -24px) scale(0.98);
+        transform: translateY(-24px) scale(0.98);
         pointer-events: none;
     }
 
@@ -748,16 +763,17 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
 
     .mobile-keypad {
         display: grid;
-        grid-template-columns: repeat(3, 36px);
-        grid-auto-rows: 36px;
+        grid-template-columns: repeat(3, 32px);
+        grid-auto-rows: 32px;
         justify-content: center;
         justify-items: center;
         align-items: center;
+        gap: 6px;
     }
 
     .mobile-keypad-button {
-        width: 36px;
-        height: 36px;
-        font-size: 0.95em;
+        width: 32px;
+        height: 32px;
+        font-size: 0.9em;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,11 @@
 /* styles.css */
 /* Rôle: Centralise tous les styles de l'application pour une maintenance facilitée. */
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     color: #1f2d3d;
@@ -8,7 +14,7 @@ body {
     margin: 0;
     min-height: 100vh;
 }
-.ui-panel { 
+.ui-panel {
     position: absolute;
     background: #ffffff;
     padding: 20px;
@@ -120,6 +126,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-wrap: nowrap;
     gap: 12px;
     box-sizing: border-box;
     background: rgba(255, 255, 255, 0.92);
@@ -156,6 +163,23 @@ body {
     color: #1f2d3d;
     border: 1px solid #c2dedb;
     box-shadow: inset 0 -2px 0 rgba(31, 45, 61, 0.05);
+}
+
+.mobile-keypad {
+    display: none;
+    flex: 0 0 auto;
+    gap: 6px;
+}
+
+.mobile-keypad-button {
+    font-size: 1em;
+    font-weight: 600;
+    touch-action: manipulation;
+}
+
+.mobile-keypad-button:active {
+    background-color: #e4f0ee;
+    border-color: #b6d8d4;
 }
 
 #controls .icon-button:hover {
@@ -543,6 +567,8 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
     border-radius: 12px;
     cursor: pointer;
     transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    min-width: 0;
+    text-align: center;
 }
 
 .mobile-tabbutton--toggle {
@@ -618,11 +644,11 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         flex-direction: column;
         justify-content: flex-start;
         align-items: stretch;
-        width: min(92vw, 320px);
-        max-width: 320px;
+        width: min(90vw, 300px);
+        max-width: 300px;
         padding-inline: clamp(8px, 4vw, 16px);
         padding-top: calc(env(safe-area-inset-top) + clamp(12px, 4vh, 24px));
-        padding-bottom: calc(env(safe-area-inset-bottom) + clamp(12px, 4vh, 24px));
+        padding-bottom: calc(env(safe-area-inset-bottom) + clamp(96px, 18vh, 140px));
         gap: clamp(16px, 6vh, 28px);
         min-height: 100vh;
         overflow-y: visible;
@@ -690,7 +716,7 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
         flex-direction: column;
         pointer-events: auto;
         opacity: 1;
-        max-height: calc(100vh - clamp(168px, 32vh, 240px));
+        max-height: calc(100vh - clamp(220px, 36vh, 300px));
         overflow-y: auto;
     }
 
@@ -712,5 +738,26 @@ a-scene[vr-mode-ui] .ui-panel, a-scene[vr-mode-ui] #version-display { display: n
 
     .mobile-panels-handle[hidden] {
         display: none;
+    }
+
+    #controls {
+        bottom: calc(env(safe-area-inset-bottom) + 18px);
+        gap: 10px;
+        padding: 10px 14px;
+    }
+
+    .mobile-keypad {
+        display: grid;
+        grid-template-columns: repeat(3, 36px);
+        grid-auto-rows: 36px;
+        justify-content: center;
+        justify-items: center;
+        align-items: center;
+    }
+
+    .mobile-keypad-button {
+        width: 36px;
+        height: 36px;
+        font-size: 0.95em;
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated mobile tab bar to switch between the stimulation and exercise panels on narrow viewports
- update the responsive CSS so the active panel fills the available height while the inactive one stays hidden on mobile
- wire new JavaScript behavior that syncs the tab selection, updates aria attributes, and supports keyboard navigation

## Testing
- Manual verification in a Chromium mobile viewport


------
https://chatgpt.com/codex/tasks/task_e_68d973be60ac83239c23b51269155b1a