### PR TITLE
Improve optical flow immersion with parallax layers and palette controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@
 - Mettre à jour le titre et l'affichage de version dans `index.html` (balise `<title>`, `#version-display`, suffixes `?v=` pour CSS/JS).
 - Adapter l'identifiant de cache dans `service-worker.js`.
 - Vérifier les éventuelles références de version dans d'autres fichiers (ex. changelog, scripts d'intégration) et maintenir la cohérence.
+- Lors d'une montée de version ou de modifications visibles par l'utilisateur, ajouter une entrée datée dans `CHANGELOG.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.79 (2025-10-16)
+
+* Les trois couches du flux optique génèrent désormais toutes leurs particules très loin en amont et les laissent traverser l'utilisateur avant recyclage pour éviter toute apparition à bout portant.
+* Ajout d'un fondu progressif proche de la caméra afin que les particules disparaissent en douceur une fois qu'elles ont dépassé le patient.
+* Mise à jour des références de version (interface et cache service worker) en 0.79.
+
 ## v0.78 (2025-10-15)
 
 * Refonte du flux optique pour une immersion immédiate : tunnel aligné sur la caméra, parallax multi-couches, palettes manuelles ou automatiques et purge complète avant régénération pour éviter le retour des sphères optocinétiques.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.78 (2025-10-15)
+
+* Refonte du flux optique pour une immersion immédiate : tunnel aligné sur la caméra, parallax multi-couches, palettes manuelles ou automatiques et purge complète avant régénération pour éviter le retour des sphères optocinétiques.
+* Encadrement de l'exercice des hauteurs avec bornes d'altitude, affichage en temps réel et décor animé (piliers lumineux, nuages et vents lointains).
+* Ajout de la désinscription des modules visuels inactifs via le `stateManager` et montée de version affichée/service worker en 0.78.
+
 ## v0.67 (2025-10-08)
 
 * Remplacement des sphères A-Frame par un nuage instancié de halos billboarding avec shader additif pour réduire les draw calls.

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.78</title>
+    <title>OW v0.79</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.78">
+    <link rel="stylesheet" href="styles.css?v=0.79">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.78</div>
+        <div id="version-display">v0.79</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -212,7 +212,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.78"></script>
+    <script type="module" src="main.js?v=0.79"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -134,6 +134,12 @@
                             <span id="height-speed-value">0.0</span>
                             <span class="control-row-unit">m/s</span>
                         </div>
+                        <div class="control-row">
+                            <span class="control-row-label">Altitude</span>
+                            <span id="height-altitude-value">0.0</span>
+                            <span class="control-row-unit">m</span>
+                        </div>
+                        <p class="control-note" id="height-altitude-range"></p>
                         <p class="instructions">Utilisez les flèches HAUT/BAS pour monter/descendre et ESPACE pour arrêter.</p>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -88,6 +88,27 @@
                     <!-- Panneau de contrôle pour le Flux Optique -->
                     <div id="optical-flow-controls" class="control-group" style="display: none;">
                         <div class="control-item optical-flow-control">
+                            <label for="optical-flow-palette-select">Ambiance</label>
+                            <select id="optical-flow-palette-select">
+                                <option value="default">Défaut (Blanc)</option>
+                                <option value="none">Aucun (Noir)</option>
+                                <option value="forest">Forêt Mystique</option>
+                                <option value="sunset">Coucher de Soleil</option>
+                                <option value="ocean">Océan Profond</option>
+                                <option value="retro">Néon Rétro</option>
+                                <option value="pastel">Tons Pastel</option>
+                                <option value="autumn">Épices d'Automne</option>
+                                <option value="aurora">Aurore Boréale</option>
+                                <option value="volcanic">Volcanique</option>
+                                <option value="cyberpunk">Cyberpunk</option>
+                                <option value="auto">Changement Automatique</option>
+                            </select>
+                        </div>
+                        <div class="control-item optical-flow-control">
+                            <label for="optical-flow-density-slider">Densité</label>
+                            <input type="range" id="optical-flow-density-slider" min="30" max="300" value="100">
+                        </div>
+                        <div class="control-item optical-flow-control">
                             <label>Vitesse</label>
                             <div class="speed-display">
                                 <span class="arrow-icon">↕</span>

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.77</title>
+    <title>OW v0.78</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.77">
+    <link rel="stylesheet" href="styles.css?v=0.78">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.77</div>
+        <div id="version-display">v0.78</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -212,7 +212,7 @@
         <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.77"></script>
+    <script type="module" src="main.js?v=0.78"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/main.js
+++ b/main.js
@@ -36,6 +36,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const verticalSpeedValue = document.getElementById('vertical-speed-value');
     const translationSpeedValue = document.getElementById('translation-speed-value');
     const heightSpeedValue = document.getElementById('height-speed-value');
+    const heightAltitudeValue = document.getElementById('height-altitude-value');
+    const heightAltitudeRange = document.getElementById('height-altitude-range');
     const cubeSpeedSlider = document.getElementById('cube-speed-slider');
     const cubeSpeedValue = document.getElementById('cube-speed-value');
     const paletteSelect = document.getElementById('palette-select');
@@ -95,6 +97,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const shouldDisplaySubmenu = moduleName && moduleName !== 'none';
         visualSubmenu.style.display = shouldDisplaySubmenu ? '' : 'none';
+
+        if (moduleName !== 'heights') {
+            if (heightAltitudeValue) {
+                heightAltitudeValue.textContent = '0.0';
+            }
+            if (heightAltitudeRange) {
+                heightAltitudeRange.textContent = '';
+            }
+        }
     }
 
     function setActiveVisualModule(moduleName) {
@@ -109,6 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const baseVisualState = {
             ...currentState.visual,
             activeModule: moduleName,
+            altitude: moduleName === 'heights' ? (currentState.visual.altitude ?? 0) : 0,
             speeds: { h: 0, v: 0, t: 0, y: 0 }
         };
 
@@ -120,6 +132,12 @@ document.addEventListener('DOMContentLoaded', () => {
             verticalSpeedValue.textContent = '0';
             translationSpeedValue.textContent = '0.0';
             heightSpeedValue.textContent = '0.0';
+            if (heightAltitudeValue) {
+                heightAltitudeValue.textContent = '0.0';
+            }
+            if (heightAltitudeRange) {
+                heightAltitudeRange.textContent = '';
+            }
             stateManager.setState({ visual: baseVisualState });
             return;
         }
@@ -204,7 +222,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     function updateSpeedDisplay() {
         const moduleName = visualSelect.value;
-        const { visual: { speeds } } = stateManager.getState();
+        const { visual: { speeds, altitude = 0 } } = stateManager.getState();
 
         if (moduleName === 'optokinetic') {
             horizontalSpeedValue.textContent = Math.round(speeds.h);
@@ -213,6 +231,11 @@ document.addEventListener('DOMContentLoaded', () => {
             translationSpeedValue.textContent = Number(speeds.t).toFixed(1);
         } else if (moduleName === 'heights') {
             heightSpeedValue.textContent = Number(speeds.y).toFixed(1);
+            if (heightAltitudeValue) {
+                heightAltitudeValue.textContent = Number(altitude).toFixed(1);
+            }
+        } else if (heightAltitudeValue) {
+            heightAltitudeValue.textContent = Number(altitude).toFixed(1);
         }
 
         requestAnimationFrame(updateSpeedDisplay);

--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const visualSelect = document.getElementById('visual-select');
     const visualSubmenu = document.getElementById('visual-submenu');
     const densitySlider = document.getElementById('density-slider');
+    const opticalFlowDensitySlider = document.getElementById('optical-flow-density-slider');
     const horizontalSpeedValue = document.getElementById('horizontal-speed-value');
     const verticalSpeedValue = document.getElementById('vertical-speed-value');
     const translationSpeedValue = document.getElementById('translation-speed-value');
@@ -38,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const cubeSpeedSlider = document.getElementById('cube-speed-slider');
     const cubeSpeedValue = document.getElementById('cube-speed-value');
     const paletteSelect = document.getElementById('palette-select');
+    const opticalFlowPaletteSelect = document.getElementById('optical-flow-palette-select');
     const recenterButton = document.getElementById('recenter-button');
     const vrMessage = document.getElementById('vr-message');
     const ambianceControl = document.getElementById('ambiance-control');
@@ -431,8 +433,21 @@ document.addEventListener('DOMContentLoaded', () => {
         e.target.blur();
     });
 
+    const syncDensityControls = (value) => {
+        if (densitySlider) {
+            densitySlider.value = value;
+        }
+        if (opticalFlowDensitySlider) {
+            opticalFlowDensitySlider.value = value;
+        }
+    };
+
     const updateDensityState = (value) => {
         const newDensity = parseInt(value, 10);
+        if (Number.isNaN(newDensity)) {
+            return;
+        }
+        syncDensityControls(newDensity);
         const currentState = stateManager.getState();
         stateManager.setState({
             visual: {
@@ -442,26 +457,65 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
-    densitySlider.addEventListener('input', (e) => {
-        updateDensityState(e.target.value);
-    });
+    if (densitySlider) {
+        densitySlider.addEventListener('input', (e) => {
+            updateDensityState(e.target.value);
+        });
 
-    densitySlider.addEventListener('change', (e) => {
-        updateDensityState(e.target.value);
-        e.target.blur();
-    });
+        densitySlider.addEventListener('change', (e) => {
+            updateDensityState(e.target.value);
+            e.target.blur();
+        });
+    }
 
-    paletteSelect.addEventListener('change', (e) => {
-        const newPalette = e.target.value;
+    if (opticalFlowDensitySlider) {
+        opticalFlowDensitySlider.addEventListener('input', (e) => {
+            updateDensityState(e.target.value);
+        });
+
+        opticalFlowDensitySlider.addEventListener('change', (e) => {
+            updateDensityState(e.target.value);
+            e.target.blur();
+        });
+    }
+
+    const syncPaletteControls = (value) => {
+        if (paletteSelect && paletteSelect.value !== value) {
+            paletteSelect.value = value;
+        }
+        if (opticalFlowPaletteSelect && opticalFlowPaletteSelect.value !== value) {
+            opticalFlowPaletteSelect.value = value;
+        }
+    };
+
+    const updatePaletteState = (value, target) => {
+        if (!value) {
+            return;
+        }
+        syncPaletteControls(value);
         const currentState = stateManager.getState();
         stateManager.setState({
             visual: {
                 ...currentState.visual,
-                palette: newPalette
+                palette: value
             }
         });
-        e.target.blur();
-    });
+        if (target) {
+            target.blur();
+        }
+    };
+
+    if (paletteSelect) {
+        paletteSelect.addEventListener('change', (e) => {
+            updatePaletteState(e.target.value, e.target);
+        });
+    }
+
+    if (opticalFlowPaletteSelect) {
+        opticalFlowPaletteSelect.addEventListener('change', (e) => {
+            updatePaletteState(e.target.value, e.target);
+        });
+    }
 
     recenterButton.addEventListener('click', (e) => {
         handleRecenter();
@@ -639,8 +693,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Initialization ---
     function initialize() {
+        const { visual } = stateManager.getState();
+        syncDensityControls(visual.density);
+        syncPaletteControls(visual.palette);
+
         setActiveVisualModule(visualSelect.value); // This will also call updateUIVisibility
-        
+
         if (cameraEl.hasLoaded) {
             handleRecenter();
         } else {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.77';
+const VERSION = '0.78';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.78';
+const VERSION = '0.79';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/utils/stateManager.js
+++ b/utils/stateManager.js
@@ -35,6 +35,19 @@ export const stateManager = {
     subscribe(callback) {
         subscribers.push(callback);
         console.log(`Un nouveau module s'est abonné. Total abonnés: ${subscribers.length}`);
+
+        let isActive = true;
+        return () => {
+            if (!isActive) {
+                return;
+            }
+            isActive = false;
+            const index = subscribers.indexOf(callback);
+            if (index !== -1) {
+                subscribers.splice(index, 1);
+                console.log(`Un module s'est désabonné. Total abonnés: ${subscribers.length}`);
+            }
+        };
     },
 
     /**

--- a/utils/stateManager.js
+++ b/utils/stateManager.js
@@ -6,7 +6,8 @@ const state = {
         activeModule: 'optokinetic', // Le module visuel actuellement sélectionné
         density: 100,             // Densité pour l'optocinétique
         palette: 'default',         // Ambiance de couleur
-        speeds: { 
+        altitude: 0,              // Altitude courante (utilisée par l'exercice Hauteurs)
+        speeds: {
             h: 0,                 // Vitesse horizontale (optocinétique)
             v: 0,                 // Vitesse verticale (optocinétique)
             t: 0,                 // Vitesse de translation (flux optique)

--- a/visuals/decor_heights.js
+++ b/visuals/decor_heights.js
@@ -70,28 +70,40 @@ export const heightsDecorModule = {
 
         // Piliers stylisés placés à différentes distances
         const pillarPositions = [
-            { x: 12, z: -10, height: 12 },
-            { x: -15, z: -6, height: 16 },
-            { x: 18, z: 8, height: 14 },
-            { x: -9, z: 14, height: 10 }
+            { x: 12, z: -10, height: 12, tone: '#7c8fa3' },
+            { x: -15, z: -6, height: 16, tone: '#6e819a' },
+            { x: 18, z: 8, height: 14, tone: '#899bb0' },
+            { x: -9, z: 14, height: 10, tone: '#7388a0' },
+            { x: 22, z: -18, height: 18, tone: '#5f738f' }
         ];
 
-        pillarPositions.forEach((pillar) => {
+        pillarPositions.forEach((pillar, index) => {
             const pillarEl = document.createElement('a-box');
             pillarEl.setAttribute('width', '2');
             pillarEl.setAttribute('depth', '2');
             pillarEl.setAttribute('height', pillar.height);
-            pillarEl.setAttribute('color', '#7c8fa3');
+            pillarEl.setAttribute('color', pillar.tone);
             pillarEl.setAttribute('position', `${pillar.x} ${pillar.height / 2 - 1.2} ${pillar.z - 2}`);
             pillarEl.setAttribute('material', 'shader: flat');
+            pillarEl.setAttribute('animation__glow', `property: material.color; dir: alternate; dur: ${12000 + index * 1500}; easing: easeInOutSine; loop: true; to: #a0b6d0`);
+
+            const capEl = document.createElement('a-cylinder');
+            capEl.setAttribute('radius', '1.2');
+            capEl.setAttribute('height', '0.6');
+            capEl.setAttribute('color', '#e4ebf6');
+            capEl.setAttribute('position', `${pillar.x} ${pillar.height - 0.9} ${pillar.z - 2}`);
+            capEl.setAttribute('material', 'shader: flat; opacity: 0.9');
+
             this.decorRoot.appendChild(pillarEl);
+            this.decorRoot.appendChild(capEl);
         });
 
         // Plates-formes flottantes simples
         const floatingPlatforms = [
-            { x: 6, y: -1, z: -10, scale: '2 0.1 2' },
-            { x: -8, y: -0.5, z: -14, scale: '1.5 0.1 1.5' },
-            { x: 10, y: 1, z: 12, scale: '1.8 0.1 1.8' }
+            { x: 6, y: -1, z: -10, scale: '2 0.1 2', hover: 0.4, phase: 0 },
+            { x: -8, y: -0.5, z: -14, scale: '1.5 0.1 1.5', hover: 0.25, phase: 2000 },
+            { x: 10, y: 1, z: 12, scale: '1.8 0.1 1.8', hover: 0.35, phase: 4000 },
+            { x: -4, y: 1.5, z: 18, scale: '1.2 0.08 2.4', hover: 0.2, phase: 1500 }
         ];
 
         floatingPlatforms.forEach((platform) => {
@@ -100,14 +112,16 @@ export const heightsDecorModule = {
             platformEl.setAttribute('scale', platform.scale);
             platformEl.setAttribute('position', `${platform.x} ${platform.y} ${platform.z}`);
             platformEl.setAttribute('material', 'shader: flat');
+            platformEl.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${10000 + platform.phase}; easing: easeInOutSine; loop: true; to: ${platform.x} ${platform.y + platform.hover} ${platform.z}; delay: ${platform.phase}`);
             this.decorRoot.appendChild(platformEl);
         });
 
         // Nuages stylisés très simples et animés lentement
         const cloudData = [
-            { x: 8, y: 6, z: -12, scale: '3 1.4 1.4', delay: 0 },
-            { x: -10, y: 7, z: 14, scale: '2.5 1.2 1.2', delay: 2000 },
-            { x: -4, y: 5, z: -16, scale: '3.4 1.5 1.5', delay: 4000 }
+            { x: 8, y: 6, z: -12, scale: '3 1.4 1.4', delay: 0, drift: 3 },
+            { x: -10, y: 7, z: 14, scale: '2.5 1.2 1.2', delay: 2000, drift: 2 },
+            { x: -4, y: 5, z: -16, scale: '3.4 1.5 1.5', delay: 4000, drift: 4 },
+            { x: 14, y: 8, z: 22, scale: '4 1.8 1.8', delay: 6000, drift: 5 }
         ];
 
         cloudData.forEach((cloud) => {
@@ -118,7 +132,67 @@ export const heightsDecorModule = {
             cloudEl.setAttribute('opacity', '0.85');
             cloudEl.setAttribute('material', 'shader: flat');
             cloudEl.setAttribute('animation__float', `property: position; dir: alternate; dur: 12000; easing: easeInOutSine; loop: true; to: ${cloud.x} ${cloud.y + 0.8} ${cloud.z}; delay: ${cloud.delay}`);
+            cloudEl.setAttribute('animation__drift', `property: position; dir: alternate; dur: ${18000 + cloud.delay}; easing: easeInOutSine; loop: true; to: ${cloud.x + cloud.drift} ${cloud.y} ${cloud.z}; delay: ${cloud.delay / 2}`);
             this.decorRoot.appendChild(cloudEl);
+        });
+
+        // Bandes de nuages lointains pour suggérer un vent doux
+        const farCloudBands = [
+            { y: 4, from: -25, to: 25, z: -35, width: 40, delay: 0 },
+            { y: 9, from: 22, to: -18, z: 38, width: 36, delay: 4000 }
+        ];
+
+        farCloudBands.forEach((band) => {
+            const bandEl = document.createElement('a-plane');
+            bandEl.setAttribute('width', `${band.width}`);
+            bandEl.setAttribute('height', '6');
+            bandEl.setAttribute('material', 'shader: flat; color: #ffffff; opacity: 0.18; side: double');
+            bandEl.setAttribute('rotation', '0 0 0');
+            bandEl.setAttribute('position', `0 ${band.y} ${band.z}`);
+            bandEl.setAttribute('animation__wind', `property: position; dir: alternate; dur: 24000; easing: easeInOutSine; loop: true; to: ${band.to} ${band.y} ${band.z}; from: ${band.from} ${band.y} ${band.z}; delay: ${band.delay}`);
+            this.decorRoot.appendChild(bandEl);
+        });
+
+        // Flux de vent lumineux pour dynamiser l'arrière-plan
+        const windTrails = [
+            { position: '-12 2 -22', rotation: '0 10 0', length: 14 },
+            { position: '16 3 28', rotation: '0 -20 0', length: 18 }
+        ];
+
+        windTrails.forEach((trail) => {
+            const trailEl = document.createElement('a-plane');
+            trailEl.setAttribute('width', `${trail.length}`);
+            trailEl.setAttribute('height', '1.6');
+            trailEl.setAttribute('material', 'shader: flat; color: #b9ddff; opacity: 0.12; side: double');
+            trailEl.setAttribute('position', trail.position);
+            trailEl.setAttribute('rotation', trail.rotation);
+            trailEl.setAttribute('animation__pulse', 'property: material.opacity; dir: alternate; dur: 3500; easing: easeInOutSine; loop: true; to: 0.22');
+            this.decorRoot.appendChild(trailEl);
+        });
+
+        // Ballons d'altitude lointains pour renforcer la perception de verticalité
+        const tetheredBalloons = [
+            { x: 20, y: 15, z: -30, color: '#ffcf66', bob: 1.6, delay: 0 },
+            { x: -24, y: 13, z: 34, color: '#8ed6ff', bob: 1.1, delay: 2200 }
+        ];
+
+        tetheredBalloons.forEach((balloon) => {
+            const balloonEl = document.createElement('a-sphere');
+            balloonEl.setAttribute('radius', '1.5');
+            balloonEl.setAttribute('color', balloon.color);
+            balloonEl.setAttribute('position', `${balloon.x} ${balloon.y} ${balloon.z}`);
+            balloonEl.setAttribute('material', 'shader: flat; opacity: 0.95');
+            balloonEl.setAttribute('animation__bob', `property: position; dir: alternate; dur: ${9000 + balloon.delay}; easing: easeInOutSine; loop: true; to: ${balloon.x} ${balloon.y + balloon.bob} ${balloon.z}; delay: ${balloon.delay}`);
+
+            const tetherEl = document.createElement('a-cylinder');
+            tetherEl.setAttribute('radius', '0.02');
+            tetherEl.setAttribute('height', `${balloon.y + 3}`);
+            tetherEl.setAttribute('color', '#f9f1d0');
+            tetherEl.setAttribute('position', `${balloon.x} ${(balloon.y - 3) / 2} ${balloon.z}`);
+            tetherEl.setAttribute('material', 'shader: flat; opacity: 0.6');
+
+            this.decorRoot.appendChild(balloonEl);
+            this.decorRoot.appendChild(tetherEl);
         });
 
         sceneEl.appendChild(this.decorRoot);

--- a/visuals/heights.js
+++ b/visuals/heights.js
@@ -13,6 +13,30 @@ let actualSpeed = 0;
 let targetSpeed = 0;
 const smoothingFactor = 2.0; // Facteur de lissage pour une décélération douce
 let lastFrameTime = 0;
+let currentAltitude = 0;
+let lastReportedAltitude = null;
+
+const MIN_ALTITUDE = -5;
+const MAX_ALTITUDE = 25;
+const ALTITUDE_REPORT_THRESHOLD = 0.02;
+let altitudeRangeEl = null;
+
+function _reportAltitude(force = false) {
+    if (!force && lastReportedAltitude !== null && Math.abs(currentAltitude - lastReportedAltitude) < ALTITUDE_REPORT_THRESHOLD) {
+        return;
+    }
+    lastReportedAltitude = currentAltitude;
+    stateManager.setState({ visual: { altitude: currentAltitude } });
+}
+
+function _syncAltitudeRangeLabel() {
+    if (!altitudeRangeEl) {
+        altitudeRangeEl = document.getElementById('height-altitude-range');
+    }
+    if (altitudeRangeEl) {
+        altitudeRangeEl.textContent = `Plage: ${MIN_ALTITUDE.toFixed(0)} m à ${MAX_ALTITUDE.toFixed(0)} m`;
+    }
+}
 
 // --- Core Logic ---
 function _createElements() {
@@ -135,11 +159,29 @@ function _animate(time) {
     }
 
     if (rigEl && platformEl && Math.abs(actualSpeed) > 0) {
-        const newY = rigEl.object3D.position.y + actualSpeed * dt; // Vitesse par seconde
-        rigEl.object3D.position.y = newY;
-        platformEl.object3D.position.y = newY;
+        const desiredY = rigEl.object3D.position.y + actualSpeed * dt; // Vitesse par seconde
+        const clampedY = Math.min(MAX_ALTITUDE, Math.max(MIN_ALTITUDE, desiredY));
+
+        if (clampedY !== desiredY) {
+            actualSpeed = 0;
+            targetSpeed = 0;
+        }
+
+        rigEl.object3D.position.y = clampedY;
+        platformEl.object3D.position.y = clampedY;
+
+        currentAltitude = clampedY;
+        _reportAltitude();
     }
-    
+
+    if (rigEl) {
+        const rigY = rigEl.object3D.position.y;
+        if (Math.abs(actualSpeed) < 0.01 && Math.abs(currentAltitude - rigY) > 0.001) {
+            currentAltitude = rigY;
+            _reportAltitude(true);
+        }
+    }
+
     animationFrameId = requestAnimationFrame(_animate);
 }
 
@@ -167,7 +209,11 @@ export const heightsModule = {
 
         _createElements();
         lastFrameTime = performance.now();
-        
+        currentAltitude = rigEl ? rigEl.object3D.position.y : 0;
+        lastReportedAltitude = null;
+        _syncAltitudeRangeLabel();
+        _reportAltitude(true);
+
         // Lancer correctement la boucle d'animation
         if (animationFrameId) {
             cancelAnimationFrame(animationFrameId);
@@ -194,10 +240,17 @@ export const heightsModule = {
         platformEl = null;
         actualSpeed = 0;
         targetSpeed = 0;
+        currentAltitude = 0;
+        lastReportedAltitude = null;
         // Réinitialiser la position du rig
         if(rigEl) {
             rigEl.object3D.position.y = 0;
         }
+        if (altitudeRangeEl) {
+            altitudeRangeEl.textContent = '';
+        }
+        altitudeRangeEl = null;
+        stateManager.setState({ visual: { altitude: 0 } });
         if (skyEl) {
             skyEl.setAttribute('color', '#000000');
         }
@@ -210,7 +263,11 @@ export const heightsModule = {
             if(platformEl) platformEl.object3D.position.y = 0;
             actualSpeed = 0;
             targetSpeed = 0;
+            currentAltitude = 0;
+            lastReportedAltitude = null;
         }
+        _syncAltitudeRangeLabel();
+        _reportAltitude(true);
     },
 
     // --- Fonctions pour les contrôles ---

--- a/visuals/heights.js
+++ b/visuals/heights.js
@@ -15,6 +15,7 @@ const smoothingFactor = 2.0; // Facteur de lissage pour une décélération douc
 let lastFrameTime = 0;
 let currentAltitude = 0;
 let lastReportedAltitude = null;
+let unsubscribeFromState = null;
 
 const MIN_ALTITUDE = -5;
 const MAX_ALTITUDE = 25;
@@ -191,7 +192,10 @@ export const heightsModule = {
         sceneEl = _sceneEl;
         rigEl = _rigEl;
 
-        stateManager.subscribe(this.onStateChange.bind(this));
+        if (unsubscribeFromState) {
+            unsubscribeFromState();
+        }
+        unsubscribeFromState = stateManager.subscribe(this.onStateChange.bind(this));
 
         // Créer le décor via son module dédié
         heightsDecorModule.create(sceneEl);
@@ -228,6 +232,10 @@ export const heightsModule = {
     },
 
     cleanup() {
+        if (unsubscribeFromState) {
+            unsubscribeFromState();
+            unsubscribeFromState = null;
+        }
         // Nettoyer le décor via son module dédié
         heightsDecorModule.cleanup();
 

--- a/visuals/opticalFlow.js
+++ b/visuals/opticalFlow.js
@@ -91,7 +91,8 @@ function _randomPositionForLayer(layer, direction = 0) {
         // Défilement inverse: privilégier l'avant immédiat.
         t = 0.75 + Math.random() * 0.25;
     } else {
-        t = Math.random();
+        // Génération initiale : garder les particules au loin pour éviter les apparitions trop proches.
+        t = Math.random() * 0.35;
     }
 
     const z = minZ + (maxZ - minZ) * t;

--- a/visuals/opticalFlow.js
+++ b/visuals/opticalFlow.js
@@ -2,9 +2,10 @@
 /* Rôle: Gère une stimulation visuelle de type flux optique (étoiles qui avancent). */
 
 import { stateManager } from '../utils/stateManager.js';
+import { colorPalettes } from '../utils/colorPalettes.js';
 
 // --- Private State ---
-let sceneEl, container;
+let sceneEl, container, rigEl, cameraEl;
 let targetSpeed = 0; // La vitesse que l'on veut atteindre
 let currentSpeed = 0; // La vitesse actuelle des particules
 const smoothingFactor = 0.05; // Contrôle la fluidité du mouvement (plus c'est petit, plus c'est fluide)
@@ -12,79 +13,280 @@ let density = 100;
 let animationFrameId;
 let stars = [];
 let lastTime = 0; // Pour calculer le timeDelta
+let selectedPaletteId = 'default';
+let activePaletteColors = colorPalettes.default;
+let autoPaletteInterval = null;
+let autoPaletteIndex = 0;
 
-// --- Core Logic ---
-function _createStar() {
-    const star = document.createElement('a-sphere');
-    const radius = 0.08 + Math.random() * 0.07; // Rayon plus grand
-    star.setAttribute('radius', radius);
-    // Matériau émissif pour être visible sans lumière
-    star.setAttribute('material', 'shader: flat; color: #FFF; emissive: #FFF; emissiveIntensity: 2');
+const MIN_TOTAL_STARS = 30;
+const AUTO_PALETTE_KEYS = Object.keys(colorPalettes);
 
-    // Start away from the camera
-    const x = (Math.random() - 0.5) * 50;
-    const y = (Math.random() - 0.5) * 50;
-    const z = -50 - Math.random() * 50; // Start far away
-    star.setAttribute('position', `${x} ${y} ${z}`);
-    
-    container.appendChild(star);
-    return { element: star, initialZ: z };
+const layerConfigs = [
+    {
+        key: 'near',
+        weight: 0.28,
+        speedFactor: 1.6,
+        radiusRange: [0.18, 0.32],
+        horizontalSpread: 22,
+        verticalSpread: 16,
+        depthRange: { near: -2.5, far: -18 },
+        resetBuffer: 1.5,
+        emissiveIntensity: 2.2
+    },
+    {
+        key: 'mid',
+        weight: 0.44,
+        speedFactor: 1.0,
+        radiusRange: [0.11, 0.22],
+        horizontalSpread: 34,
+        verticalSpread: 24,
+        depthRange: { near: -16, far: -55 },
+        resetBuffer: 2,
+        emissiveIntensity: 1.8
+    },
+    {
+        key: 'far',
+        weight: 0.28,
+        speedFactor: 0.55,
+        radiusRange: [0.06, 0.15],
+        horizontalSpread: 48,
+        verticalSpread: 32,
+        depthRange: { near: -45, far: -140 },
+        resetBuffer: 3,
+        emissiveIntensity: 1.3
+    }
+];
+
+const tempPosition = new THREE.Vector3();
+const tempQuaternion = new THREE.Quaternion();
+const tempRigQuaternion = new THREE.Quaternion();
+const tempEuler = new THREE.Euler();
+
+// --- Helpers ---
+function _getActivePaletteColors() {
+    if (Array.isArray(activePaletteColors) && activePaletteColors.length > 0) {
+        return activePaletteColors;
+    }
+    return ['#FFFFFF'];
 }
 
-function _resetStar(starData) {
-    const x = (Math.random() - 0.5) * 50;
-    const y = (Math.random() - 0.5) * 50;
-    const z = -50 - Math.random() * 50;
+function _randomInRange(min, max) {
+    return min + Math.random() * (max - min);
+}
+
+function _pickRadius([min, max]) {
+    return _randomInRange(min, max);
+}
+
+function _randomPositionForLayer(layer, direction = 0) {
+    const { horizontalSpread, verticalSpread, depthRange } = layer;
+    const minZ = Math.min(depthRange.near, depthRange.far);
+    const maxZ = Math.max(depthRange.near, depthRange.far);
+    let t;
+
+    if (direction > 0) {
+        // Défilement vers l'utilisateur: privilégier les profondeurs lointaines.
+        t = Math.random() * 0.25;
+    } else if (direction < 0) {
+        // Défilement inverse: privilégier l'avant immédiat.
+        t = 0.75 + Math.random() * 0.25;
+    } else {
+        t = Math.random();
+    }
+
+    const z = minZ + (maxZ - minZ) * t;
+    const x = (Math.random() - 0.5) * horizontalSpread;
+    const y = (Math.random() - 0.5) * verticalSpread;
+
+    return { x, y, z };
+}
+
+function _applyMaterial(starElement, color, intensity) {
+    starElement.setAttribute(
+        'material',
+        `shader: flat; color: ${color}; emissive: ${color}; emissiveIntensity: ${intensity}`
+    );
+}
+
+function _applyColorToStar(starData, forceNewIndex = false) {
+    const colors = _getActivePaletteColors();
+    const colorCount = colors.length;
+    if (forceNewIndex || typeof starData.colorIndex !== 'number') {
+        starData.colorIndex = Math.floor(Math.random() * colorCount);
+    }
+    const color = colors[starData.colorIndex % colorCount];
+    _applyMaterial(starData.element, color, starData.layer.emissiveIntensity);
+}
+
+function _alignContainerToCamera() {
+    if (!container || !cameraEl) {
+        return;
+    }
+
+    cameraEl.object3D.getWorldPosition(tempPosition);
+    container.object3D.position.copy(tempPosition);
+
+    cameraEl.object3D.getWorldQuaternion(tempQuaternion);
+    if (rigEl) {
+        tempRigQuaternion.copy(rigEl.object3D.quaternion).invert();
+        tempQuaternion.premultiply(tempRigQuaternion);
+    }
+
+    tempEuler.setFromQuaternion(tempQuaternion, 'YXZ');
+    tempEuler.x = 0;
+    tempEuler.z = 0;
+    container.object3D.quaternion.setFromEuler(tempEuler);
+}
+
+function _stopAutoPalette() {
+    if (autoPaletteInterval) {
+        clearInterval(autoPaletteInterval);
+        autoPaletteInterval = null;
+    }
+}
+
+function _cycleAutoPalette() {
+    if (!AUTO_PALETTE_KEYS.length) {
+        activePaletteColors = ['#FFFFFF'];
+        return;
+    }
+
+    const paletteKey = AUTO_PALETTE_KEYS[autoPaletteIndex % AUTO_PALETTE_KEYS.length];
+    autoPaletteIndex = (autoPaletteIndex + 1) % AUTO_PALETTE_KEYS.length;
+    const palette = colorPalettes[paletteKey];
+    if (Array.isArray(palette) && palette.length > 0) {
+        activePaletteColors = palette;
+    } else {
+        activePaletteColors = ['#FFFFFF'];
+    }
+    _applyPaletteToStars(true);
+}
+
+function _startAutoPalette() {
+    _stopAutoPalette();
+    autoPaletteIndex = 0;
+    _cycleAutoPalette();
+    autoPaletteInterval = setInterval(_cycleAutoPalette, 10000);
+}
+
+function _applyPaletteToStars(forceNewIndex = false) {
+    const colors = _getActivePaletteColors();
+    const colorCount = colors.length;
+    if (colorCount === 0) {
+        return;
+    }
+    for (const star of stars) {
+        if (forceNewIndex) {
+            star.colorIndex = Math.floor(Math.random() * colorCount);
+        }
+        star.colorIndex = star.colorIndex % colorCount;
+        const color = colors[star.colorIndex];
+        _applyMaterial(star.element, color, star.layer.emissiveIntensity);
+    }
+}
+
+// --- Core Logic ---
+function _createStar(layer) {
+    const star = document.createElement('a-sphere');
+    const radius = _pickRadius(layer.radiusRange);
+    star.setAttribute('radius', radius);
+
+    const initialPosition = _randomPositionForLayer(layer, 0);
+    star.setAttribute('position', `${initialPosition.x} ${initialPosition.y} ${initialPosition.z}`);
+
+    container.appendChild(star);
+
+    const starData = {
+        element: star,
+        layer,
+        speedFactor: layer.speedFactor,
+        colorIndex: Math.floor(Math.random() * _getActivePaletteColors().length)
+    };
+
+    _applyColorToStar(starData);
+
+    return starData;
+}
+
+function _resetStar(starData, direction = 0) {
+    const { x, y, z } = _randomPositionForLayer(starData.layer, direction);
+    starData.element.object3D.position.set(x, y, z);
     starData.element.setAttribute('position', `${x} ${y} ${z}`);
+    _applyColorToStar(starData, true);
+}
+
+function _computeLayerCounts(total) {
+    const counts = layerConfigs.map(layer => Math.floor(total * layer.weight));
+    let assigned = counts.reduce((sum, value) => sum + value, 0);
+    let remainder = total - assigned;
+    let index = 0;
+    while (remainder > 0) {
+        counts[index % counts.length] += 1;
+        remainder -= 1;
+        index += 1;
+    }
+    // S'assure qu'il y a au moins une étoile par couche
+    for (let i = 0; i < counts.length; i += 1) {
+        if (counts[i] === 0) {
+            counts[i] = 1;
+        }
+    }
+    return counts;
 }
 
 function _generateStars() {
-    // Clean up existing stars
+    if (!container) {
+        return;
+    }
+
+    _alignContainerToCamera();
+
     while (container.firstChild) {
         container.removeChild(container.firstChild);
     }
     stars = [];
 
-    for (let i = 0; i < density; i++) {
-        stars.push(_createStar());
-    }
+    const totalStars = Math.max(MIN_TOTAL_STARS, density);
+    const counts = _computeLayerCounts(totalStars);
+
+    layerConfigs.forEach((layer, index) => {
+        const count = counts[index];
+        for (let i = 0; i < count; i += 1) {
+            stars.push(_createStar(layer));
+        }
+    });
+
+    _applyPaletteToStars();
 }
 
 // --- Animation Logic ---
 function _animate(time) {
-    // On ne reçoit que 'time' de requestAnimationFrame. On calcule timeDelta manuellement.
     if (lastTime === 0) {
         lastTime = time;
     }
     const timeDelta = time - lastTime;
     lastTime = time;
 
-    // Lissage de la vitesse
     currentSpeed += (targetSpeed - currentSpeed) * smoothingFactor;
 
-    // Si la vitesse est très proche de zéro, on l'arrête complètement
     if (Math.abs(currentSpeed) < 0.01) {
         currentSpeed = 0;
     }
 
-    // On ne met à jour que si la vitesse n'est pas nulle et que le temps a avancé
     if (currentSpeed !== 0 && timeDelta > 0) {
-        const deltaSeconds = timeDelta / 1000; // Mouvement basé sur le temps réel écoulé
-        const cameraPosition = sceneEl.camera.el.object3D.position;
-
+        const deltaSeconds = timeDelta / 1000;
         for (const starData of stars) {
-            let pos = starData.element.getAttribute('position');
-            
-            // Vitesse (m/s) * temps (s) = distance (m)
-            // Le '0.1' précédent rendait la vitesse perçue différente de la vitesse affichée.
-            // On l'enlève pour une vitesse 1:1.
-            pos.z += currentSpeed * deltaSeconds; 
+            const position = starData.element.object3D.position;
+            position.z += currentSpeed * deltaSeconds * starData.speedFactor;
 
-            // If star is behind the camera, reset it
-            if (pos.z > cameraPosition.z) {
-                _resetStar(starData);
-            } else {
-                starData.element.setAttribute('position', pos);
+            const { near, far } = starData.layer.depthRange;
+            const nearLimit = Math.max(near, far) + starData.layer.resetBuffer;
+            const farLimit = Math.min(near, far) - starData.layer.resetBuffer;
+
+            if (currentSpeed >= 0 && position.z >= nearLimit) {
+                _resetStar(starData, 1);
+            } else if (currentSpeed < 0 && position.z <= farLimit) {
+                _resetStar(starData, -1);
             }
         }
     }
@@ -96,8 +298,14 @@ function _animate(time) {
 export const opticalFlowModule = {
     init(_sceneEl, _rigEl, _cameraEl, _container) {
         sceneEl = _sceneEl;
+        rigEl = _rigEl;
+        cameraEl = _cameraEl;
         container = _container;
-        
+
+        _stopAutoPalette();
+        selectedPaletteId = null;
+        activePaletteColors = colorPalettes.default;
+
         stateManager.subscribe(this.onStateChange.bind(this));
 
         _generateStars();
@@ -110,7 +318,22 @@ export const opticalFlowModule = {
     },
 
     onStateChange(newState) {
-        this.setSpeed(newState.visual.speeds.t);
+        if (!newState || !newState.visual) {
+            return;
+        }
+
+        const { visual } = newState;
+        if (visual.speeds && typeof visual.speeds.t === 'number') {
+            this.setSpeed(visual.speeds.t);
+        }
+
+        if (typeof visual.density === 'number' && visual.density !== density) {
+            this.setDensity(visual.density);
+        }
+
+        if (visual.palette && visual.palette !== selectedPaletteId) {
+            this.setPalette(visual.palette);
+        }
     },
 
     regenerate() {
@@ -120,7 +343,7 @@ export const opticalFlowModule = {
     setSpeed(newSpeed) {
         targetSpeed = newSpeed;
     },
-    
+
     getActualSpeed() {
         return { h: 0, v: 0, t: currentSpeed }; // Report speed back to UI
     },
@@ -131,8 +354,25 @@ export const opticalFlowModule = {
     },
 
     setPalette(paletteId) {
-        // Not implemented for this simple module
-        // All stars are white
+        if (!paletteId) {
+            return;
+        }
+
+        selectedPaletteId = paletteId;
+
+        if (paletteId === 'auto') {
+            _startAutoPalette();
+            return;
+        }
+
+        _stopAutoPalette();
+        const palette = colorPalettes[paletteId];
+        if (Array.isArray(palette) && palette.length > 0) {
+            activePaletteColors = palette;
+        } else {
+            activePaletteColors = ['#FFFFFF'];
+        }
+        _applyPaletteToStars(true);
     },
 
     cleanup() {
@@ -140,8 +380,11 @@ export const opticalFlowModule = {
             cancelAnimationFrame(animationFrameId);
             animationFrameId = null;
         }
-        while (container.firstChild) {
-            container.removeChild(container.firstChild);
+        _stopAutoPalette();
+        if (container) {
+            while (container.firstChild) {
+                container.removeChild(container.firstChild);
+            }
         }
         stars = [];
         currentSpeed = 0;

--- a/visuals/opticalFlow.js
+++ b/visuals/opticalFlow.js
@@ -79,6 +79,23 @@ function _pickRadius([min, max]) {
     return _randomInRange(min, max);
 }
 
+function _clearContainerChildren() {
+    if (!container) {
+        return;
+    }
+
+    while (container.firstChild) {
+        container.removeChild(container.firstChild);
+    }
+
+    const object3D = container.object3D;
+    if (object3D) {
+        for (let i = object3D.children.length - 1; i >= 0; i -= 1) {
+            object3D.remove(object3D.children[i]);
+        }
+    }
+}
+
 function _randomPositionForLayer(layer, direction = 0) {
     const { horizontalSpread, verticalSpread, depthRange } = layer;
     const minZ = Math.min(depthRange.near, depthRange.far);
@@ -159,9 +176,10 @@ function _stopAutoPalette() {
     autoPaletteKeys = [];
 }
 
-function _cycleAutoPalette() {
+function _applyAutoPalette() {
     if (!autoPaletteKeys.length) {
         activePaletteColors = ['#FFFFFF'];
+        _applyPaletteToStars(true);
         return;
     }
 
@@ -169,7 +187,7 @@ function _cycleAutoPalette() {
     autoPaletteIndex = (autoPaletteIndex + 1) % autoPaletteKeys.length;
     const palette = colorPalettes[paletteKey];
     if (Array.isArray(palette) && palette.length > 0) {
-        activePaletteColors = palette;
+        activePaletteColors = palette.slice();
     } else {
         activePaletteColors = ['#FFFFFF'];
     }
@@ -179,14 +197,11 @@ function _cycleAutoPalette() {
 function _startAutoPalette() {
     _stopAutoPalette();
     _refreshAutoPaletteKeys();
-    if (!autoPaletteKeys.length) {
-        activePaletteColors = ['#FFFFFF'];
-        _applyPaletteToStars(true);
-        return;
-    }
     autoPaletteIndex = 0;
-    _cycleAutoPalette();
-    autoPaletteInterval = setInterval(_cycleAutoPalette, 10000);
+    _applyAutoPalette();
+    if (autoPaletteKeys.length) {
+        autoPaletteInterval = setInterval(_applyAutoPalette, 10000);
+    }
 }
 
 function _applyPaletteToStars(forceNewIndex = false) {
@@ -261,9 +276,7 @@ function _generateStars() {
 
     _alignContainerToCamera();
 
-    while (container.firstChild) {
-        container.removeChild(container.firstChild);
-    }
+    _clearContainerChildren();
     stars = [];
 
     const totalStars = Math.max(MIN_TOTAL_STARS, density);
@@ -409,9 +422,7 @@ export const opticalFlowModule = {
         }
         _stopAutoPalette();
         if (container) {
-            while (container.firstChild) {
-                container.removeChild(container.firstChild);
-            }
+            _clearContainerChildren();
         }
         stars = [];
         currentSpeed = 0;

--- a/visuals/optokinetic.js
+++ b/visuals/optokinetic.js
@@ -27,6 +27,7 @@ let instancedMaterial = null;
 let haloTexture = null;
 let fadeAnimationId = null;
 const MAX_PALETTE_COLORS = 8;
+let unsubscribeFromState = null;
 
 const tempCameraQuat = new THREE.Quaternion();
 const tempCameraRight = new THREE.Vector3(1, 0, 0);
@@ -375,7 +376,10 @@ export const optokineticModule = {
         spheresContainer = _spheresContainer;
 
         // S'abonner aux changements d'état
-        stateManager.subscribe(this.onStateChange.bind(this));
+        if (unsubscribeFromState) {
+            unsubscribeFromState();
+        }
+        unsubscribeFromState = stateManager.subscribe(this.onStateChange.bind(this));
 
         // Récupérer l'état initial pour la première génération
         const initialState = stateManager.getState();
@@ -478,12 +482,15 @@ export const optokineticModule = {
     },
 
     cleanup() {
+        if (unsubscribeFromState) {
+            unsubscribeFromState();
+            unsubscribeFromState = null;
+        }
         if (animationFrameId) {
             cancelAnimationFrame(animationFrameId);
             animationFrameId = null;
         }
         _stopAutoColorCycle();
         _disposeInstancedResources();
-        // TODO: Se désabonner du stateManager
     }
 };

--- a/visuals/rotatingCube.js
+++ b/visuals/rotatingCube.js
@@ -9,6 +9,7 @@ let sceneEl;
 let cubeEl;
 let animationFrameId;
 let rotationSpeed = 0.5; // Vitesse de rotation en degrés par frame
+let unsubscribeFromState = null;
 
 // --- Core Logic ---
 
@@ -32,7 +33,10 @@ function _animate() {
 export const rotatingCubeModule = {
     init(_sceneEl, _rigEl, _cameraEl, _container) {
         sceneEl = _sceneEl;
-        stateManager.subscribe(this.onStateChange.bind(this));
+        if (unsubscribeFromState) {
+            unsubscribeFromState();
+        }
+        unsubscribeFromState = stateManager.subscribe(this.onStateChange.bind(this));
         _createCube();
         _animate();
     },
@@ -44,6 +48,10 @@ export const rotatingCubeModule = {
     },
 
     cleanup() {
+        if (unsubscribeFromState) {
+            unsubscribeFromState();
+            unsubscribeFromState = null;
+        }
         if (animationFrameId) {
             cancelAnimationFrame(animationFrameId);
         }


### PR DESCRIPTION
## Summary
- move and recenter the optical flow particle field around the user for immediate immersion
- add multi-layer parallax stars with density and palette handling, including auto palette cycling
- expose optical flow density and palette controls and keep them synchronized with existing UI sliders

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd43fde8c083239f74cc1c3eff368a