### PR TITLE
feat: support manettes Oculus pour l'optocinétique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.83 (2025-10-20)
+
+* Ajout du mapping des manettes Oculus Touch : le joystick ajuste les vitesses de l'optocinétique et les boutons A/X recentrent tandis que B/Y arrêtent la rotation.
+* Mise à jour des références de version (interface et cache service worker) en 0.83.
+
 ## v0.82 (2025-10-19)
 
 * Ajout d'espaces tampons dans les panneaux mobiles pour que les curseurs, sélecteurs et boutons restent visibles au-dessus du bandeau de contrôle Recentrer.

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.82</title>
+    <title>OW v0.83</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.82">
+    <link rel="stylesheet" href="styles.css?v=0.83">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.82</div>
+        <div id="version-display">v0.83</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -211,10 +211,14 @@
 
         <a-sky id="sky" color="#000000"></a-sky>
         <a-entity id="spheres"></a-entity>
-        <a-entity id="rig" position="0 0 0"><a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera></a-entity>
+        <a-entity id="rig" position="0 0 0">
+            <a-camera look-controls-enabled="true" wasd-controls-enabled="false"></a-camera>
+            <a-entity id="left-controller" laser-controls="hand: left"></a-entity>
+            <a-entity id="right-controller" laser-controls="hand: right"></a-entity>
+        </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.82"></script>
+    <script type="module" src="main.js?v=0.83"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/main.js
+++ b/main.js
@@ -657,6 +657,59 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const vrControllerStates = new WeakMap();
+    const thumbstickThreshold = 0.4;
+
+    const bindVRController = (controllerEl) => {
+        if (!controllerEl || vrControllerStates.has(controllerEl)) {
+            return;
+        }
+
+        const controllerState = { horizontal: null, vertical: null };
+        vrControllerStates.set(controllerEl, controllerState);
+
+        controllerEl.addEventListener('thumbstickmoved', (event) => {
+            const { x = 0, y = 0 } = event.detail || {};
+            const nextHorizontal = Math.abs(x) > thumbstickThreshold ? (x > 0 ? 'arrowright' : 'arrowleft') : null;
+            const nextVertical = Math.abs(y) > thumbstickThreshold ? (y < 0 ? 'arrowup' : 'arrowdown') : null;
+
+            if (nextHorizontal !== controllerState.horizontal) {
+                controllerState.horizontal = nextHorizontal;
+                if (nextHorizontal) {
+                    handleControlInput(nextHorizontal);
+                }
+            }
+
+            if (nextVertical !== controllerState.vertical) {
+                controllerState.vertical = nextVertical;
+                if (nextVertical) {
+                    handleControlInput(nextVertical);
+                }
+            }
+        });
+
+        const triggerRecenter = () => handleControlInput('r');
+        const triggerStop = () => handleControlInput(' ');
+
+        controllerEl.addEventListener('abuttondown', triggerRecenter);
+        controllerEl.addEventListener('xbuttondown', triggerRecenter);
+        controllerEl.addEventListener('bbuttondown', triggerStop);
+        controllerEl.addEventListener('ybuttondown', triggerStop);
+    };
+
+    const setupVRControllers = () => {
+        const controllerSelector = '#rig [laser-controls]';
+        const existingControllers = document.querySelectorAll(controllerSelector);
+        existingControllers.forEach((controllerEl) => bindVRController(controllerEl));
+
+        sceneEl.addEventListener('controllerconnected', (event) => {
+            const controllerEl = event.target;
+            if (controllerEl && controllerEl.matches && controllerEl.matches(controllerSelector)) {
+                bindVRController(controllerEl);
+            }
+        });
+    };
+
     document.addEventListener('keydown', (event) => {
         handleControlInput(event.key);
     });
@@ -680,7 +733,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     sceneEl.addEventListener('enter-vr', () => {
         vrMessage.style.display = 'flex';
-        handleRecenter(); 
+        handleRecenter();
     });
 
     sceneEl.addEventListener('exit-vr', () => { 
@@ -737,4 +790,5 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     initialize();
+    setupVRControllers();
 });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.82';
+const VERSION = '0.83';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);


### PR DESCRIPTION
## Résumé
- branchement des manettes Oculus Touch pour piloter les mêmes actions que les flèches et boutons clavier (rotation, recentrage, arrêt)
- ajout explicite des entités contrôleurs dans la scène A-Frame
- passage de la version affichée/service worker en 0.83 avec mise à jour du changelog

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68e3825347588323bc6fac51a04874d1