### PR TITLE
Refine VR controller bindings and release v0.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.85 (2025-10-21)
+
+* Refonte du mapping des manettes Oculus Touch : A et clic joystick droit recentrent, B stoppe la rotation et X/Y ajustent la vitesse verticale.
+* Mise à jour des références de version (interface et cache service worker) en 0.85.
+
 ## v0.83 (2025-10-20)
 
 * Ajout du mapping des manettes Oculus Touch : le joystick ajuste les vitesses de l'optocinétique et les boutons A/X recentrent tandis que B/Y arrêtent la rotation.

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.83</title>
+    <title>OW v0.85</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.83">
+    <link rel="stylesheet" href="styles.css?v=0.85">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.83</div>
+        <div id="version-display">v0.85</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -218,7 +218,7 @@
         </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.83"></script>
+    <script type="module" src="main.js?v=0.85"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/main.js
+++ b/main.js
@@ -690,11 +690,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const triggerRecenter = () => handleControlInput('r');
         const triggerStop = () => handleControlInput(' ');
+        const triggerVerticalIncrease = () => handleControlInput('arrowup');
+        const triggerVerticalDecrease = () => handleControlInput('arrowdown');
 
         controllerEl.addEventListener('abuttondown', triggerRecenter);
-        controllerEl.addEventListener('xbuttondown', triggerRecenter);
         controllerEl.addEventListener('bbuttondown', triggerStop);
-        controllerEl.addEventListener('ybuttondown', triggerStop);
+        controllerEl.addEventListener('ybuttondown', triggerVerticalIncrease);
+        controllerEl.addEventListener('xbuttondown', triggerVerticalDecrease);
+
+        if (controllerEl.id === 'right-controller') {
+            controllerEl.addEventListener('thumbstickdown', triggerRecenter);
+        }
     };
 
     const setupVRControllers = () => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.83';
+const VERSION = '0.85';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);


### PR DESCRIPTION
## Summary
- remap the Oculus controller inputs so A and the right thumbstick click recenter, B stops the rotation, and X/Y control the vertical speed steps
- bump the public version markers and service-worker cache id to 0.85 and document the change

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e39d0984e48323b7653d30690260c1