### PR TITLE
Améliorer l'environnement de l'exercice des hauteurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.87 (2025-10-22)
+
+* Harmonisation complète des couleurs des hauteurs avec les palettes optocinétiques et recoloration dynamique de la plateforme.
+* Ajout de nouvelles tours proches/lointaines, de montagnes agrandies et d'éléments éloignés plus variés pour renforcer la sensation d'ascension.
+
 ## v0.86 (2025-10-22)
 
 * Le flux optique affiche désormais un paquet de particules proches dès le lancement et ne recycle les points qu'une fois passés derrière l'utilisateur, pour que la direction soit immédiatement lisible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.88 (2025-10-23)
+
+* Horizon des hauteurs élargi avec un disque de sol plus vaste et des terrasses étagées plus larges pour accentuer la sensation de profondeur.
+* Ajout de chaînes montagneuses lointaines plus hautes avec sommets enneigés et nouveaux reliefs visibles même en décor épuré.
+* Meilleure répartition des éléments en mode épuré grâce à des tours, arbres et piliers supplémentaires autour de la plateforme.
+* Nouveau sélecteur d'ambiance de couleur directement dans les réglages des hauteurs.
+
 ## v0.87 (2025-10-22)
 
 * Harmonisation complète des couleurs des hauteurs avec les palettes optocinétiques et recoloration dynamique de la plateforme.

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.86</title>
+    <title>OW v0.87</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.86">
+    <link rel="stylesheet" href="styles.css?v=0.87">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.86</div>
+        <div id="version-display">v0.87</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -230,7 +230,7 @@
         </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.86"></script>
+    <script type="module" src="main.js?v=0.87"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -139,7 +139,19 @@
                             <label class="heights-control-label" for="height-platform-size">Plateforme</label>
                             <select id="height-platform-size">
                                 <option value="1">Taille normale</option>
+                                <option value="0.75">Taille réduite (75&nbsp;%)</option>
                                 <option value="0.5">Taille réduite (50&nbsp;%)</option>
+                                <option value="0.35">Taille compacte (35&nbsp;%)</option>
+                                <option value="0.25">Taille minimale (25&nbsp;%)</option>
+                            </select>
+                        </div>
+                        <div class="control-item heights-control">
+                            <label class="heights-control-label" for="height-decor-density">Décor</label>
+                            <select id="height-decor-density">
+                                <option value="minimal">Épuré</option>
+                                <option value="standard">Standard</option>
+                                <option value="rich">Riche</option>
+                                <option value="immersive" selected>Immersif</option>
                             </select>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.87</title>
+    <title>OW v0.88</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.87">
+    <link rel="stylesheet" href="styles.css?v=0.88">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.87</div>
+        <div id="version-display">v0.88</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -146,6 +146,23 @@
                             </select>
                         </div>
                         <div class="control-item heights-control">
+                            <label class="heights-control-label" for="height-palette-select">Ambiance</label>
+                            <select id="height-palette-select">
+                                <option value="default">Défaut (Blanc)</option>
+                                <option value="none">Aucun (Noir)</option>
+                                <option value="forest">Forêt Mystique</option>
+                                <option value="sunset">Coucher de Soleil</option>
+                                <option value="ocean">Océan Profond</option>
+                                <option value="retro">Néon Rétro</option>
+                                <option value="pastel">Tons Pastel</option>
+                                <option value="autumn">Épices d'Automne</option>
+                                <option value="aurora">Aurore Boréale</option>
+                                <option value="volcanic">Volcanique</option>
+                                <option value="cyberpunk">Cyberpunk</option>
+                                <option value="auto">Changement Automatique</option>
+                            </select>
+                        </div>
+                        <div class="control-item heights-control">
                             <label class="heights-control-label" for="height-decor-density">Décor</label>
                             <select id="height-decor-density">
                                 <option value="minimal">Épuré</option>
@@ -230,7 +247,7 @@
         </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.87"></script>
+    <script type="module" src="main.js?v=0.88"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/main.js
+++ b/main.js
@@ -37,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const heightSpeedValue = document.getElementById('height-speed-value');
     const heightAltitudeValue = document.getElementById('height-altitude-value');
     const heightPlatformSizeSelect = document.getElementById('height-platform-size');
+    const heightDecorDensitySelect = document.getElementById('height-decor-density');
     const paletteSelect = document.getElementById('palette-select');
     const opticalFlowPaletteSelect = document.getElementById('optical-flow-palette-select');
     const recenterButton = document.getElementById('recenter-button');
@@ -97,9 +98,14 @@ document.addEventListener('DOMContentLoaded', () => {
             heightAltitudeValue.textContent = '0.0';
         }
 
-        if (moduleName === 'heights' && heightPlatformSizeSelect) {
-            const { visual: { platformScale = 1 } } = stateManager.getState();
-            heightPlatformSizeSelect.value = platformScale.toString();
+        if (moduleName === 'heights') {
+            const { visual: { platformScale = 1, heightsDecorDensity = 'immersive' } } = stateManager.getState();
+            if (heightPlatformSizeSelect) {
+                heightPlatformSizeSelect.value = platformScale.toString();
+            }
+            if (heightDecorDensitySelect) {
+                heightDecorDensitySelect.value = heightsDecorDensity;
+            }
         }
     }
 
@@ -117,6 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
             activeModule: moduleName,
             altitude: moduleName === 'heights' ? (currentState.visual.altitude ?? 0) : 0,
             platformScale: currentState.visual.platformScale ?? 1,
+            heightsDecorDensity: currentState.visual.heightsDecorDensity ?? 'immersive',
             speeds: { h: 0, v: 0, t: 0, y: 0 }
         };
 
@@ -768,6 +775,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const initialScale = visual.platformScale ?? 1;
             heightPlatformSizeSelect.value = initialScale.toString();
         }
+        if (heightDecorDensitySelect) {
+            const initialDensity = visual.heightsDecorDensity ?? 'immersive';
+            heightDecorDensitySelect.value = initialDensity;
+        }
 
         setActiveVisualModule(visualSelect.value); // This will also call updateUIVisibility
 
@@ -804,6 +815,32 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (activeVisualModule && typeof activeVisualModule.setPlatformScale === 'function') {
                 activeVisualModule.setPlatformScale(selectedScale);
+            }
+        });
+    }
+
+    if (heightDecorDensitySelect) {
+        const allowedDensityLevels = ['minimal', 'standard', 'rich', 'immersive'];
+        heightDecorDensitySelect.addEventListener('change', () => {
+            const selectedDensity = heightDecorDensitySelect.value;
+            if (!allowedDensityLevels.includes(selectedDensity)) {
+                return;
+            }
+
+            const currentState = stateManager.getState();
+            if (currentState.visual.heightsDecorDensity === selectedDensity) {
+                return;
+            }
+
+            const updatedVisual = {
+                ...currentState.visual,
+                heightsDecorDensity: selectedDensity
+            };
+
+            stateManager.setState({ visual: updatedVisual });
+
+            if (activeVisualModule && typeof activeVisualModule.setDecorDensity === 'function') {
+                activeVisualModule.setDecorDensity(selectedDensity);
             }
         });
     }

--- a/main.js
+++ b/main.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const heightAltitudeValue = document.getElementById('height-altitude-value');
     const heightPlatformSizeSelect = document.getElementById('height-platform-size');
     const heightDecorDensitySelect = document.getElementById('height-decor-density');
+    const heightPaletteSelect = document.getElementById('height-palette-select');
     const paletteSelect = document.getElementById('palette-select');
     const opticalFlowPaletteSelect = document.getElementById('optical-flow-palette-select');
     const recenterButton = document.getElementById('recenter-button');
@@ -99,12 +100,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (moduleName === 'heights') {
-            const { visual: { platformScale = 1, heightsDecorDensity = 'immersive' } } = stateManager.getState();
+            const { visual: { platformScale = 1, heightsDecorDensity = 'immersive', palette = 'default' } } = stateManager.getState();
             if (heightPlatformSizeSelect) {
                 heightPlatformSizeSelect.value = platformScale.toString();
             }
             if (heightDecorDensitySelect) {
                 heightDecorDensitySelect.value = heightsDecorDensity;
+            }
+            if (heightPaletteSelect) {
+                heightPaletteSelect.value = palette;
             }
         }
     }
@@ -509,6 +513,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (opticalFlowPaletteSelect && opticalFlowPaletteSelect.value !== value) {
             opticalFlowPaletteSelect.value = value;
         }
+        if (heightPaletteSelect && heightPaletteSelect.value !== value) {
+            heightPaletteSelect.value = value;
+        }
     };
 
     const updatePaletteState = (value, target) => {
@@ -536,6 +543,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (opticalFlowPaletteSelect) {
         opticalFlowPaletteSelect.addEventListener('change', (e) => {
+            updatePaletteState(e.target.value, e.target);
+        });
+    }
+
+    if (heightPaletteSelect) {
+        heightPaletteSelect.addEventListener('change', (e) => {
             updatePaletteState(e.target.value, e.target);
         });
     }
@@ -778,6 +791,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (heightDecorDensitySelect) {
             const initialDensity = visual.heightsDecorDensity ?? 'immersive';
             heightDecorDensitySelect.value = initialDensity;
+        }
+        if (heightPaletteSelect) {
+            heightPaletteSelect.value = visual.palette ?? 'default';
         }
 
         setActiveVisualModule(visualSelect.value); // This will also call updateUIVisibility

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.86';
+const VERSION = '0.87';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.87';
+const VERSION = '0.88';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/utils/stateManager.js
+++ b/utils/stateManager.js
@@ -8,6 +8,7 @@ const state = {
         palette: 'default',         // Ambiance de couleur
         altitude: 0,              // Altitude courante (utilisée par l'exercice Hauteurs)
         platformScale: 1,         // Facteur d'échelle de la plateforme des hauteurs
+        heightsDecorDensity: 'immersive', // Niveau de richesse du décor pour l'exercice Hauteurs
         speeds: {
             h: 0,                 // Vitesse horizontale (optocinétique)
             v: 0,                 // Vitesse verticale (optocinétique)

--- a/visuals/decor_heights.js
+++ b/visuals/decor_heights.js
@@ -1,6 +1,373 @@
 /* /visuals/decor_heights.js */
 
+import { colorPalettes, lerpColor } from '../utils/colorPalettes.js';
+
 const DENSITY_LEVELS = ['minimal', 'standard', 'rich', 'immersive'];
+
+const CLOSE_TOWER_CONFIGS = [
+    { x: 3.2, z: -5.2, height: 18, baseRadius: 0.75, width: 1.1, depth: 1.05, minDensity: 'minimal' },
+    { x: -3.0, z: -5.4, height: 19, baseRadius: 0.75, width: 1.05, depth: 1.05, minDensity: 'minimal' },
+    { x: 4.8, z: -2.8, height: 17, baseRadius: 0.72, width: 0.95, depth: 1.0, minDensity: 'minimal' },
+    { x: -5.1, z: -2.6, height: 17.5, baseRadius: 0.72, width: 1.0, depth: 1.05, minDensity: 'minimal' },
+    { x: 2.4, z: -6.8, height: 20, baseRadius: 0.82, width: 1.15, depth: 1.15, minDensity: 'standard' },
+    { x: -2.2, z: -7.2, height: 21, baseRadius: 0.85, width: 1.2, depth: 1.2, minDensity: 'standard' },
+    { x: 0.8, z: -3.6, height: 22, baseRadius: 0.9, width: 1.35, depth: 1.1, minDensity: 'rich' },
+    { x: -0.9, z: -3.4, height: 23, baseRadius: 0.92, width: 1.35, depth: 1.15, minDensity: 'rich' },
+    { x: 5.9, z: 0.6, height: 18, baseRadius: 0.7, width: 1.05, depth: 0.95, minDensity: 'rich' },
+    { x: -6.2, z: 0.8, height: 18.5, baseRadius: 0.7, width: 1.0, depth: 1.0, minDensity: 'rich' },
+    { x: 3.8, z: 2.4, height: 17.5, baseRadius: 0.68, width: 0.95, depth: 1.0, minDensity: 'immersive' },
+    { x: -4.0, z: 2.8, height: 18, baseRadius: 0.68, width: 0.98, depth: 1.0, minDensity: 'immersive' }
+];
+
+const MEGA_TOWER_CONFIGS = [
+    { x: 10, z: -14, height: 30, baseRadius: 1.1, width: 1.8, depth: 1.8, minDensity: 'standard' },
+    { x: -12, z: -16, height: 32, baseRadius: 1.15, width: 1.9, depth: 1.9, minDensity: 'standard' },
+    { x: 14, z: 12, height: 34, baseRadius: 1.2, width: 2.1, depth: 2.2, minDensity: 'rich' },
+    { x: -16, z: 10, height: 33, baseRadius: 1.2, width: 2.0, depth: 2.3, minDensity: 'rich' },
+    { x: 20, z: -6, height: 36, baseRadius: 1.3, width: 2.4, depth: 2.3, minDensity: 'immersive' },
+    { x: -22, z: -4, height: 38, baseRadius: 1.35, width: 2.6, depth: 2.5, minDensity: 'immersive' },
+    { x: 18, z: 18, height: 32, baseRadius: 1.25, width: 2.2, depth: 2.1, minDensity: 'immersive' }
+];
+
+const WALKWAY_CONFIGS = [
+    { x: 0, y: 4.8, z: -4.6, width: 6, depth: 1.1, hover: 0.4, minDensity: 'standard' },
+    { x: 0, y: 7.5, z: -4.6, width: 5, depth: 0.8, hover: 0.32, minDensity: 'rich' },
+    { x: 0, y: 9.8, z: -4.6, width: 4, depth: 0.7, hover: 0.26, minDensity: 'immersive' }
+];
+
+const ARCH_CONFIGS = [
+    { x: 3.5, z: -5.4, height: 6.6, width: 3.2, minDensity: 'standard' },
+    { x: -3.5, z: -5.4, height: 6.3, width: 3.4, minDensity: 'standard' },
+    { x: 0, z: -8.2, height: 7.8, width: 4.5, minDensity: 'rich' },
+    { x: 0, z: -10.6, height: 8.4, width: 4.2, minDensity: 'immersive' }
+];
+
+const PILLAR_CONFIGS = [
+    { x: 12, z: -10, height: 24, width: 2.4, depth: 2.2, minDensity: 'minimal' },
+    { x: -18, z: -4, height: 28, width: 2.8, depth: 2.4, minDensity: 'minimal' },
+    { x: 22, z: 12, height: 26, width: 2.2, depth: 2.8, minDensity: 'standard' },
+    { x: -10, z: 18, height: 22, width: 2.1, depth: 2.1, minDensity: 'standard' },
+    { x: 28, z: -22, height: 30, width: 2.6, depth: 2.4, minDensity: 'rich' },
+    { x: -26, z: -18, height: 32, width: 3.2, depth: 2.6, minDensity: 'rich' },
+    { x: 16, z: 26, height: 36, width: 3.4, depth: 3.1, minDensity: 'immersive' },
+    { x: -30, z: 24, height: 34, width: 2.9, depth: 3.5, minDensity: 'immersive' },
+    { x: 32, z: -6, height: 25, width: 2.5, depth: 3.0, minDensity: 'immersive' },
+    { x: -14, z: 32, height: 29, width: 2.3, depth: 2.6, minDensity: 'immersive' }
+];
+
+const FLOATING_PLATFORM_CONFIGS = [
+    { x: 6, y: -1, z: -10, scale: '2.4 0.12 2.4', hover: 0.4, delay: 0, minDensity: 'rich' },
+    { x: -8, y: -0.5, z: -14, scale: '1.8 0.1 1.8', hover: 0.25, delay: 2000, minDensity: 'rich' },
+    { x: 10, y: 1, z: 12, scale: '2 0.1 2', hover: 0.35, delay: 4000, minDensity: 'rich' },
+    { x: -4, y: 1.5, z: 18, scale: '1.4 0.08 2.6', hover: 0.2, delay: 1500, minDensity: 'rich' },
+    { x: 12, y: 2.2, z: -6, scale: '1.6 0.12 1.6', hover: 0.28, delay: 3200, minDensity: 'immersive' },
+    { x: -12, y: 2.8, z: 10, scale: '1.9 0.1 2.4', hover: 0.3, delay: 3800, minDensity: 'immersive' }
+];
+
+const CLOUD_CONFIGS = [
+    { x: 8, y: 9, z: -12, scale: '3.2 1.4 1.4', delay: 0, drift: 3, minDensity: 'minimal' },
+    { x: -10, y: 10, z: 14, scale: '2.7 1.2 1.2', delay: 2000, drift: 2, minDensity: 'minimal' },
+    { x: -4, y: 8, z: -16, scale: '3.6 1.5 1.5', delay: 4000, drift: 4, minDensity: 'standard' },
+    { x: 14, y: 11, z: 22, scale: '4.2 1.8 1.8', delay: 6000, drift: 5, minDensity: 'standard' },
+    { x: 18, y: 12, z: -20, scale: '3.5 1.4 1.4', delay: 800, drift: 4, minDensity: 'rich' },
+    { x: -20, y: 13, z: 26, scale: '3.8 1.6 1.6', delay: 2400, drift: 3.5, minDensity: 'rich' },
+    { x: 6, y: 14, z: 30, scale: '4.6 1.8 1.8', delay: 5200, drift: 5.5, minDensity: 'immersive' },
+    { x: -16, y: 15, z: -28, scale: '5 1.9 1.9', delay: 1000, drift: 3.5, minDensity: 'immersive' },
+    { x: 18, y: 16, z: 30, scale: '5.2 1.9 1.9', delay: 2500, drift: 4.5, minDensity: 'immersive' },
+    { x: 4, y: 14, z: 26, scale: '3.8 1.5 1.5', delay: 4200, drift: 3, minDensity: 'immersive' }
+];
+
+const FAR_CLOUD_BANDS = [
+    { y: 4, from: -25, to: 25, z: -35, width: 40, delay: 0, minDensity: 'standard' },
+    { y: 9, from: 22, to: -18, z: 38, width: 36, delay: 4000, minDensity: 'standard' },
+    { y: 12, from: -32, to: 32, z: -42, width: 48, delay: 2600, minDensity: 'immersive' }
+];
+
+const WIND_TRAIL_CONFIGS = [
+    { position: '-12 2 -22', rotation: '0 10 0', length: 14, minDensity: 'standard' },
+    { position: '16 3 28', rotation: '0 -20 0', length: 18, minDensity: 'standard' },
+    { position: '8 6 -16', rotation: '0 15 0', length: 12, minDensity: 'rich' },
+    { position: '-18 7 20', rotation: '0 -25 0', length: 16, minDensity: 'immersive' }
+];
+
+const BALLOON_CONFIGS = [
+    { x: 20, y: 15, z: -30, bob: 1.6, delay: 0, minDensity: 'rich' },
+    { x: -24, y: 13, z: 34, bob: 1.1, delay: 2200, minDensity: 'rich' },
+    { x: 10, y: 18, z: 18, bob: 1.8, delay: 1800, minDensity: 'immersive' },
+    { x: -18, y: 17, z: -24, bob: 1.4, delay: 1400, minDensity: 'immersive' }
+];
+
+const TREE_CONFIGS = [
+    { x: 26, z: -14, trunkHeight: 3.2, canopyScale: '2.6 2.8 2.6', sway: 0.18, minDensity: 'minimal' },
+    { x: -28, z: -10, trunkHeight: 4, canopyScale: '3 3.4 3', sway: 0.24, minDensity: 'minimal' },
+    { x: 24, z: 18, trunkHeight: 3.6, canopyScale: '2.4 2.6 2.4', sway: 0.16, minDensity: 'standard' },
+    { x: -22, z: 22, trunkHeight: 3.8, canopyScale: '2.8 3 2.8', sway: 0.2, minDensity: 'standard' },
+    { x: 30, z: 28, trunkHeight: 4.4, canopyScale: '2.2 2.4 2.2', sway: 0.14, minDensity: 'rich' },
+    { x: -34, z: 18, trunkHeight: 4.8, canopyScale: '2.6 2.9 2.6', sway: 0.22, minDensity: 'rich' },
+    { x: 20, z: -28, trunkHeight: 3.4, canopyScale: '2.3 2.5 2.3', sway: 0.17, minDensity: 'immersive' },
+    { x: -26, z: -24, trunkHeight: 4.2, canopyScale: '2.9 3.1 2.9', sway: 0.19, minDensity: 'immersive' },
+    { x: 16, z: 32, trunkHeight: 3.6, canopyScale: '2.4 2.5 2.4', sway: 0.21, minDensity: 'immersive' },
+    { x: -32, z: 30, trunkHeight: 4.6, canopyScale: '2.8 3.2 2.8', sway: 0.2, minDensity: 'immersive' }
+];
+
+const MOUNTAIN_CONFIGS = [
+    { x: 18, z: -32, height: 22, radius: 12, minDensity: 'standard' },
+    { x: -14, z: -36, height: 26, radius: 13, minDensity: 'standard' },
+    { x: 26, z: 40, height: 28, radius: 14, minDensity: 'rich' },
+    { x: -30, z: 36, height: 30, radius: 16, minDensity: 'rich' },
+    { x: 10, z: 48, height: 24, radius: 11, minDensity: 'rich' },
+    { x: -6, z: -46, height: 30, radius: 14, minDensity: 'immersive' },
+    { x: 36, z: -32, height: 32, radius: 15, minDensity: 'immersive' },
+    { x: -38, z: 30, height: 34, radius: 16, minDensity: 'immersive' },
+    { x: 42, z: 44, height: 36, radius: 18, minDensity: 'immersive' }
+];
+
+const LANTERN_CONFIGS = [
+    { x: 2, y: 12, z: -6, path: '2 12 -6, 3 14 -7, 2 13 -8' },
+    { x: -3, y: 13, z: -5, path: '-3 13 -5, -2 14 -6, -3 12 -7' },
+    { x: 1, y: 11, z: -3, path: '1 11 -3, 2 12 -2, 1 13 -1' }
+];
+
+function clamp01(value) {
+    return Math.max(0, Math.min(1, value));
+}
+
+function mixColors(colorA, colorB, amount) {
+    return lerpColor(colorA, colorB, clamp01(amount));
+}
+
+function lighten(color, amount) {
+    return mixColors(color, '#ffffff', amount);
+}
+
+function darken(color, amount) {
+    return mixColors(color, '#000000', amount);
+}
+
+function getDefaultTheme() {
+    return {
+        skyColor: '#8dc6ff',
+        fogColor: '#d6ecff',
+        groundPlaneColor: '#f0e3c0',
+        groundRingColor: '#d7c5a3',
+        terracesColors: ['#d3d9dc', '#b9c6cf', '#9fb3c4'],
+        coreColumnColor: '#1f2a44',
+        platformBaseColor: '#2c3e50',
+        platformTopColor: '#4a90e2',
+        platformMarkerColor: '#f8f9fa',
+        platformStripeColor: '#d9e8ff',
+        platformPostColor: '#cfd9e8',
+        platformRailColor: '#b3c4e0',
+        towerBaseColor: '#3d4f6c',
+        towerBodyColors: ['#ff9a9e', '#fad0c4', '#f6abb6', '#ffb7c3', '#c3bef0', '#a3bffa', '#f8b195', '#f67280', '#99c1de', '#9ad5ca'],
+        towerAccentColors: ['#ffe5ec', '#ffeacb', '#ffd3e1', '#ffe0ea', '#dfd7ff', '#cdd9ff', '#ffd4b8', '#ff9ba9', '#c1ddf1', '#c4ede1'],
+        towerGlowColors: ['#fff3e6', '#fffaf0', '#ffeef5', '#fff3f8', '#f5f2ff', '#f0f4ff', '#fff1e6', '#ffdce3', '#e8f5ff', '#e7fff7'],
+        walkwayDeckColors: ['#4a6fa3', '#547bb5', '#5f88c8'],
+        walkwayGuardColor: '#c4d7ff',
+        archBaseColor: '#495e84',
+        archRingColors: ['#aec5ff', '#bcd3ff', '#9db4ff', '#c2b5ff'],
+        archAccentColors: ['#deecff', '#e4f1ff', '#d4e2ff', '#ebe5ff'],
+        pillarBaseColor: '#516482',
+        pillarBodyColors: ['#6f84a3', '#5f7a9a', '#7d90ab', '#6a809d', '#567190', '#4f6a88', '#627b99', '#556f8d', '#6d89a5', '#5c7694'],
+        pillarAccentColors: ['#a2b9d8', '#97b0d3', '#b1c6e2', '#9cb2d1', '#8ea7c9', '#89a3c4', '#aac0dc', '#96b2d3', '#a7bedc', '#95afd0'],
+        pillarGlowColor: '#f0f6ff',
+        floatingPlatformColors: ['#c6d6e5', '#b5cade', '#c8dff5', '#bcd0e6', '#d0e2f6', '#d6e8fb'],
+        cloudColor: '#ffffff',
+        cloudBandColor: '#d9e6f5',
+        windColor: '#b9ddff',
+        balloonColors: ['#ffcf66', '#8ed6ff', '#ff9eb5', '#ffd3a4'],
+        treeTrunkColor: '#6b4f2c',
+        treeCanopyColors: ['#7ec87c', '#6fc47a', '#8cd290', '#75c080', '#82c88a', '#6abd78', '#78c684', '#89ce92', '#7dd68f', '#6ccb7c'],
+        treeHighlightColors: ['#a8e0a2', '#97de9f', '#b6e9b8', '#a6e0ae', '#b2e3b7', '#9ddc9f', '#a7e0b0', '#bce8c1', '#adefc2', '#99ecaf'],
+        mountainMainColors: ['#7286a0', '#6b7c96', '#7088a8', '#677d96', '#8097b2', '#647791', '#5f7087', '#5a6c82', '#6d7c95'],
+        mountainSecondaryColors: ['#7f93ad', '#7a8fa8', '#7d9ab4', '#7489a1', '#8499b7', '#72839b'],
+        mountainHighlightColor: '#d9e6f5',
+        lanternColors: ['#ffe08a', '#ffd1ff', '#b5f0ff']
+    };
+}
+
+function getMonochromeTheme() {
+    const theme = getDefaultTheme();
+    const base = '#1f1f1f';
+    const light = '#e0e0e0';
+    const mid = '#808080';
+    const accent = '#b0b0b0';
+    const highlight = '#f5f5f5';
+
+    theme.skyColor = '#0a0a0a';
+    theme.fogColor = '#0f0f0f';
+    theme.groundPlaneColor = mixColors(base, light, 0.2);
+    theme.groundRingColor = mixColors(base, light, 0.25);
+    theme.terracesColors = [mixColors(base, light, 0.35), mixColors(base, light, 0.45), mixColors(base, light, 0.55)];
+    theme.coreColumnColor = mixColors(base, '#000000', 0.6);
+    theme.platformBaseColor = mixColors(base, '#000000', 0.4);
+    theme.platformTopColor = mixColors(mid, light, 0.2);
+    theme.platformMarkerColor = highlight;
+    theme.platformStripeColor = mixColors(accent, highlight, 0.5);
+    theme.platformPostColor = mixColors(base, light, 0.35);
+    theme.platformRailColor = mixColors(accent, highlight, 0.4);
+    theme.towerBaseColor = mixColors(base, '#000000', 0.5);
+    theme.towerBodyColors = [mixColors(base, accent, 0.25), mixColors(base, accent, 0.35), mixColors(base, accent, 0.45), mixColors(base, accent, 0.55)];
+    theme.towerAccentColors = theme.towerBodyColors.map(color => mixColors(color, highlight, 0.4));
+    theme.towerGlowColors = theme.towerAccentColors.map(color => mixColors(color, highlight, 0.5));
+    theme.walkwayDeckColors = [mixColors(base, mid, 0.4), mixColors(base, mid, 0.3), mixColors(base, mid, 0.2)];
+    theme.walkwayGuardColor = mixColors(accent, highlight, 0.4);
+    theme.archBaseColor = mixColors(base, '#000000', 0.55);
+    theme.archRingColors = [mixColors(base, mid, 0.3), mixColors(base, mid, 0.4), mixColors(base, mid, 0.5), mixColors(base, mid, 0.6)];
+    theme.archAccentColors = theme.archRingColors.map(color => mixColors(color, highlight, 0.35));
+    theme.pillarBaseColor = mixColors(base, '#000000', 0.5);
+    theme.pillarBodyColors = [mixColors(base, mid, 0.35), mixColors(base, mid, 0.4), mixColors(base, mid, 0.45), mixColors(base, mid, 0.5)];
+    theme.pillarAccentColors = theme.pillarBodyColors.map(color => mixColors(color, highlight, 0.35));
+    theme.pillarGlowColor = mixColors(accent, highlight, 0.6);
+    theme.floatingPlatformColors = [mixColors(base, mid, 0.4), mixColors(base, mid, 0.5), mixColors(base, mid, 0.6)];
+    theme.cloudColor = mixColors(mid, highlight, 0.6);
+    theme.cloudBandColor = mixColors(mid, highlight, 0.4);
+    theme.windColor = mixColors(mid, highlight, 0.45);
+    theme.balloonColors = [mixColors(base, accent, 0.5), mixColors(mid, light, 0.5), mixColors(accent, highlight, 0.5)];
+    theme.treeTrunkColor = mixColors(base, '#3a2a1a', 0.6);
+    theme.treeCanopyColors = [mixColors(base, mid, 0.5), mixColors(base, mid, 0.55), mixColors(base, mid, 0.6)];
+    theme.treeHighlightColors = theme.treeCanopyColors.map(color => mixColors(color, highlight, 0.35));
+    theme.mountainMainColors = [mixColors(base, mid, 0.45), mixColors(base, mid, 0.5), mixColors(base, mid, 0.55)];
+    theme.mountainSecondaryColors = [mixColors(base, mid, 0.35), mixColors(base, mid, 0.4)];
+    theme.mountainHighlightColor = mixColors(accent, highlight, 0.5);
+    theme.lanternColors = [mixColors(accent, highlight, 0.5), mixColors(mid, highlight, 0.5), mixColors(base, accent, 0.5)];
+
+    return theme;
+}
+
+function buildThemeFromPalette(palette) {
+    const theme = getDefaultTheme();
+    if (!Array.isArray(palette) || palette.length === 0) {
+        return theme;
+    }
+
+    const safePalette = palette.filter(Boolean);
+    if (safePalette.length === 0) {
+        return theme;
+    }
+
+    const getColor = (index) => safePalette[index % safePalette.length];
+    const base = getColor(0);
+    const accent = getColor(1);
+    const tertiary = getColor(2);
+    const quaternary = getColor(3);
+    const quinary = getColor(4);
+
+    theme.skyColor = lighten(quinary, 0.75);
+    theme.fogColor = lighten(quinary, 0.88);
+    theme.groundPlaneColor = lighten(base, 0.65);
+    theme.groundRingColor = lighten(base, 0.45);
+    theme.terracesColors = [lighten(base, 0.75), lighten(accent, 0.62), lighten(tertiary, 0.52)];
+    theme.coreColumnColor = darken(base, 0.55);
+
+    theme.platformBaseColor = darken(base, 0.5);
+    theme.platformTopColor = lighten(accent, 0.35);
+    theme.platformMarkerColor = lighten(quinary, 0.9);
+    theme.platformStripeColor = lighten(quinary, 0.85);
+    theme.platformPostColor = lighten(base, 0.7);
+    theme.platformRailColor = lighten(quinary, 0.75);
+
+    const towerBase = darken(base, 0.6);
+    theme.towerBaseColor = towerBase;
+    theme.towerBodyColors = [
+        lighten(accent, 0.35),
+        lighten(accent, 0.5),
+        lighten(tertiary, 0.35),
+        lighten(tertiary, 0.5),
+        lighten(quinary, 0.35),
+        lighten(quinary, 0.5)
+    ];
+    theme.towerAccentColors = theme.towerBodyColors.map(color => lighten(color, 0.3));
+    theme.towerGlowColors = theme.towerAccentColors.map(color => lighten(color, 0.35));
+
+    theme.walkwayDeckColors = [
+        darken(tertiary, 0.35),
+        darken(tertiary, 0.25),
+        darken(quaternary, 0.25)
+    ];
+    theme.walkwayGuardColor = lighten(quinary, 0.82);
+
+    theme.archBaseColor = darken(base, 0.45);
+    theme.archRingColors = [
+        lighten(accent, 0.6),
+        lighten(tertiary, 0.6),
+        lighten(quinary, 0.6),
+        lighten(quaternary, 0.6)
+    ];
+    theme.archAccentColors = theme.archRingColors.map(color => lighten(color, 0.25));
+
+    theme.pillarBaseColor = darken(base, 0.55);
+    theme.pillarBodyColors = [
+        darken(accent, 0.2),
+        darken(tertiary, 0.2),
+        darken(quinary, 0.2),
+        darken(quaternary, 0.2)
+    ];
+    theme.pillarAccentColors = theme.pillarBodyColors.map(color => lighten(color, 0.5));
+    theme.pillarGlowColor = lighten(quinary, 0.92);
+
+    theme.floatingPlatformColors = [
+        lighten(base, 0.7),
+        lighten(accent, 0.7),
+        lighten(tertiary, 0.7),
+        lighten(quinary, 0.7)
+    ];
+
+    theme.cloudColor = lighten(quinary, 0.92);
+    theme.cloudBandColor = lighten(quinary, 0.85);
+    theme.windColor = lighten(quinary, 0.88);
+
+    theme.balloonColors = [
+        lighten(accent, 0.75),
+        lighten(tertiary, 0.75),
+        lighten(quinary, 0.75),
+        lighten(quaternary, 0.75)
+    ];
+
+    theme.treeTrunkColor = mixColors(darken(base, 0.7), '#5a3a1a', 0.55);
+    theme.treeCanopyColors = [
+        lighten(accent, 0.4),
+        lighten(tertiary, 0.4),
+        lighten(quinary, 0.4)
+    ];
+    theme.treeHighlightColors = theme.treeCanopyColors.map(color => lighten(color, 0.25));
+
+    theme.mountainMainColors = [
+        darken(base, 0.25),
+        darken(accent, 0.25),
+        darken(tertiary, 0.3)
+    ];
+    theme.mountainSecondaryColors = [
+        darken(quinary, 0.2),
+        darken(quaternary, 0.25)
+    ];
+    theme.mountainHighlightColor = lighten(quinary, 0.7);
+
+    theme.lanternColors = [
+        lighten(accent, 0.85),
+        lighten(quinary, 0.85),
+        lighten(tertiary, 0.85)
+    ];
+
+    return theme;
+}
+
+function getThemeForPalette(paletteKey) {
+    if (paletteKey === 'none') {
+        return getMonochromeTheme();
+    }
+
+    if (paletteKey === 'default' || paletteKey === 'auto' || !paletteKey) {
+        return getDefaultTheme();
+    }
+
+    const palette = colorPalettes[paletteKey];
+    if (!palette || palette.length === 0) {
+        return getDefaultTheme();
+    }
+
+    return buildThemeFromPalette(palette);
+}
 
 function isLevelAtLeast(currentLevel, requiredLevel) {
     return DENSITY_LEVELS.indexOf(currentLevel) >= DENSITY_LEVELS.indexOf(requiredLevel);
@@ -17,33 +384,36 @@ function createEntity(tagName, attributes = {}, parent) {
     return element;
 }
 
-function addBaseStructures(root) {
+function selectColor(colors, index) {
+    if (!Array.isArray(colors) || colors.length === 0) {
+        return '#ffffff';
+    }
+    return colors[index % colors.length];
+}
+
+function addBaseStructures(root, theme) {
     createEntity('a-entity', {
         geometry: 'primitive: circle; radius: 58; segments: 96',
-        material: 'shader: flat; roughness: 0.8; color: #f0e3c0',
+        material: `shader: flat; roughness: 0.8; color: ${theme.groundPlaneColor}`,
         rotation: '-90 0 0',
         position: '0 -1.2 -2'
     }, root);
 
     createEntity('a-entity', {
         geometry: 'primitive: torus; radius: 58; radiusTubular: 0.6; segmentsTubular: 32; segmentsRadial: 12',
-        material: 'color: #d7c5a3; shader: flat; metalness: 0.05; roughness: 0.6',
+        material: `color: ${theme.groundRingColor}; shader: flat; metalness: 0.05; roughness: 0.6`,
         rotation: '90 0 0',
         position: '0 -1.45 -2'
     }, root);
 
-    const terraces = [
-        { radius: 25, y: -4, color: '#d3d9dc' },
-        { radius: 18, y: -6.5, color: '#b9c6cf' },
-        { radius: 12, y: -9, color: '#9fb3c4' }
-    ];
-
-    terraces.forEach((terrace) => {
+    theme.terracesColors.forEach((color, index) => {
+        const radius = [25, 18, 12][index] || 10;
+        const y = [-4, -6.5, -9][index] || -11;
         createEntity('a-cylinder', {
-            radius: terrace.radius,
+            radius: radius.toString(),
             height: '0.4',
-            color: terrace.color,
-            position: `0 ${terrace.y} -2`,
+            color,
+            position: `0 ${y} -2`,
             material: 'shader: flat'
         }, root);
     });
@@ -51,28 +421,15 @@ function addBaseStructures(root) {
     createEntity('a-cylinder', {
         radius: '6',
         height: '14',
-        color: '#1f2a44',
+        color: theme.coreColumnColor,
         opacity: '0.85',
         position: '0 -8.5 -2',
         material: 'shader: flat'
     }, root);
 }
 
-function addCloseTowerRing(root, densityLevel) {
-    const towerConfigs = [
-        { x: 3.5, z: -5, height: 16, bodyColor: '#ff9a9e', accent: '#ffe5ec', glow: '#fff3e6', minDensity: 'minimal' },
-        { x: -3.2, z: -5.2, height: 17, bodyColor: '#fad0c4', accent: '#ffeacb', glow: '#fffaf0', minDensity: 'minimal' },
-        { x: 5.2, z: -2.5, height: 15, bodyColor: '#f6abb6', accent: '#ffd3e1', glow: '#ffeef5', minDensity: 'minimal' },
-        { x: -5.4, z: -2.2, height: 15.5, bodyColor: '#ffb7c3', accent: '#ffe0ea', glow: '#fff3f8', minDensity: 'minimal' },
-        { x: 2.2, z: -7, height: 18.5, bodyColor: '#c3bef0', accent: '#dfd7ff', glow: '#f5f2ff', minDensity: 'standard' },
-        { x: -1.8, z: -7.4, height: 19, bodyColor: '#a3bffa', accent: '#cdd9ff', glow: '#f0f4ff', minDensity: 'standard' },
-        { x: 6.2, z: 0.2, height: 14, bodyColor: '#f8b195', accent: '#ffd4b8', glow: '#fff1e6', minDensity: 'rich' },
-        { x: -6.5, z: 0.4, height: 14.5, bodyColor: '#f67280', accent: '#ff9ba9', glow: '#ffdce3', minDensity: 'rich' },
-        { x: 4.2, z: 2.2, height: 13.8, bodyColor: '#99c1de', accent: '#c1ddf1', glow: '#e8f5ff', minDensity: 'immersive' },
-        { x: -4.4, z: 2.6, height: 14.2, bodyColor: '#9ad5ca', accent: '#c4ede1', glow: '#e7fff7', minDensity: 'immersive' }
-    ];
-
-    towerConfigs.forEach((tower, index) => {
+function addCloseTowerRing(root, densityLevel, theme) {
+    CLOSE_TOWER_CONFIGS.forEach((tower, index) => {
         if (!isLevelAtLeast(densityLevel, tower.minDensity)) {
             return;
         }
@@ -82,37 +439,39 @@ function addCloseTowerRing(root, densityLevel) {
         }, root);
 
         createEntity('a-cylinder', {
-            radius: '0.75',
+            radius: tower.baseRadius.toString(),
             height: '1.2',
-            color: '#3d4f6c',
+            color: theme.towerBaseColor,
             position: '0 0.6 0',
             material: 'shader: flat'
         }, group);
 
+        const bodyColor = selectColor(theme.towerBodyColors, index);
         createEntity('a-box', {
-            width: '1.05',
-            depth: '1.05',
+            width: tower.width.toString(),
+            depth: tower.depth.toString(),
             height: tower.height,
             position: `0 ${(tower.height / 2) + 1.2} 0`,
-            color: tower.bodyColor,
+            color: bodyColor,
             material: 'shader: flat; metalness: 0.12; roughness: 0.35'
         }, group);
 
-        const ringRadius = 0.85;
+        const accentColor = selectColor(theme.towerAccentColors, index);
         for (let i = 0; i < 3; i += 1) {
             const ringHeight = 2 + i * (tower.height / 3);
             createEntity('a-torus', {
-                radius: ringRadius,
+                radius: (tower.width * 0.5 + 0.3).toFixed(2),
                 radiusTubular: 0.06,
-                material: `shader: flat; color: ${tower.accent}`,
+                material: `shader: flat; color: ${accentColor}`,
                 rotation: '90 0 0',
                 position: `0 ${ringHeight + 1.2} 0`
             }, group);
         }
 
+        const glowColor = selectColor(theme.towerGlowColors, index);
         createEntity('a-sphere', {
             radius: '0.9',
-            color: tower.glow,
+            color: glowColor,
             material: 'shader: flat; opacity: 0.85',
             position: `0 ${tower.height + 1.7} 0`,
             animation__pulse: `property: scale; dir: alternate; dur: ${9000 + index * 650}; easing: easeInOutSine; loop: true; to: 1.1 1.18 1.1`
@@ -120,28 +479,68 @@ function addCloseTowerRing(root, densityLevel) {
     });
 }
 
-function addHoveringWalkways(root, densityLevel) {
-    if (!isLevelAtLeast(densityLevel, 'standard')) {
-        return;
-    }
+function addMegaTowers(root, densityLevel, theme) {
+    MEGA_TOWER_CONFIGS.forEach((tower, index) => {
+        if (!isLevelAtLeast(densityLevel, tower.minDensity)) {
+            return;
+        }
 
-    const walkwayConfigs = [
-        { x: 0, y: 4.8, z: -4.6, width: 6, depth: 1.1, color: '#4a6fa3', minDensity: 'standard' },
-        { x: 0, y: 7.5, z: -4.6, width: 5, depth: 0.8, color: '#547bb5', minDensity: 'rich' },
-        { x: 0, y: 9.8, z: -4.6, width: 4, depth: 0.7, color: '#5f88c8', minDensity: 'immersive' }
-    ];
+        const group = createEntity('a-entity', {
+            position: `${tower.x} -1.1 ${tower.z - 2}`
+        }, root);
 
-    walkwayConfigs.forEach((walkway, index) => {
+        createEntity('a-cylinder', {
+            radius: tower.baseRadius.toString(),
+            height: '1.4',
+            color: theme.towerBaseColor,
+            position: '0 0.7 0',
+            material: 'shader: flat'
+        }, group);
+
+        const bodyColor = selectColor(theme.towerBodyColors, index + CLOSE_TOWER_CONFIGS.length);
+        createEntity('a-box', {
+            width: tower.width.toString(),
+            depth: tower.depth.toString(),
+            height: tower.height,
+            position: `0 ${(tower.height / 2) + 1.4} 0`,
+            color: bodyColor,
+            material: 'shader: flat; metalness: 0.16; roughness: 0.38'
+        }, group);
+
+        const accentColor = selectColor(theme.towerAccentColors, index + 2);
+        for (let i = 0; i < 4; i += 1) {
+            const ringHeight = 3 + i * (tower.height / 4.5);
+            createEntity('a-torus', {
+                radius: (tower.width * 0.55 + 0.45).toFixed(2),
+                radiusTubular: 0.08,
+                material: `shader: flat; color: ${accentColor}`,
+                rotation: '90 0 0',
+                position: `0 ${ringHeight + 1.4} 0`
+            }, group);
+        }
+
+        const glowColor = selectColor(theme.towerGlowColors, index + 2);
+        createEntity('a-entity', {
+            geometry: 'primitive: cone; radiusBottom: 0.7; radiusTop: 0.1; height: 2.2',
+            position: `0 ${tower.height + 2.6} 0`,
+            material: `shader: flat; color: ${glowColor}; opacity: 0.85`
+        }, group);
+    });
+}
+
+function addHoveringWalkways(root, densityLevel, theme) {
+    WALKWAY_CONFIGS.forEach((walkway, index) => {
         if (!isLevelAtLeast(densityLevel, walkway.minDensity)) {
             return;
         }
 
+        const color = selectColor(theme.walkwayDeckColors, index);
         const platform = createEntity('a-box', {
             width: walkway.width,
             depth: walkway.depth,
             height: '0.12',
             position: `${walkway.x} ${walkway.y} ${walkway.z}`,
-            color: walkway.color,
+            color,
             material: 'shader: flat; metalness: 0.08; roughness: 0.45'
         }, root);
 
@@ -150,7 +549,7 @@ function addHoveringWalkways(root, densityLevel) {
             depth: '0.08',
             height: '0.4',
             position: `${walkway.x} ${walkway.y + 0.25} ${walkway.z + (walkway.depth / 2)}`,
-            color: '#c4d7ff',
+            color: theme.walkwayGuardColor,
             material: 'shader: flat; opacity: 0.65'
         }, root);
 
@@ -159,35 +558,28 @@ function addHoveringWalkways(root, densityLevel) {
             depth: '0.08',
             height: '0.4',
             position: `${walkway.x} ${walkway.y + 0.25} ${walkway.z - (walkway.depth / 2)}`,
-            color: '#c4d7ff',
+            color: theme.walkwayGuardColor,
             material: 'shader: flat; opacity: 0.65'
         }, root);
 
-        platform.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${12000 + index * 1600}; easing: easeInOutSine; loop: true; to: ${walkway.x} ${walkway.y + 0.4} ${walkway.z}`);
+        platform.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${12000 + index * 1600}; easing: easeInOutSine; loop: true; to: ${walkway.x} ${walkway.y + walkway.hover} ${walkway.z}`);
     });
 }
 
-function addArches(root, densityLevel) {
-    if (!isLevelAtLeast(densityLevel, 'standard')) {
-        return;
-    }
-
-    const archConfigs = [
-        { x: 3.5, z: -4.6, height: 6.4, width: 3.2, color: '#aec5ff', accent: '#deecff', minDensity: 'standard' },
-        { x: -3.5, z: -4.6, height: 6.1, width: 3.4, color: '#bcd3ff', accent: '#e4f1ff', minDensity: 'standard' },
-        { x: 0, z: -7.8, height: 7.8, width: 4.5, color: '#9db4ff', accent: '#d4e2ff', minDensity: 'rich' },
-        { x: 0, z: -1.2, height: 5.5, width: 3.6, color: '#c2b5ff', accent: '#ebe5ff', minDensity: 'immersive' }
-    ];
-
-    archConfigs.forEach((arch, index) => {
+function addArches(root, densityLevel, theme) {
+    ARCH_CONFIGS.forEach((arch, index) => {
         if (!isLevelAtLeast(densityLevel, arch.minDensity)) {
             return;
         }
 
-        const baseLeft = createEntity('a-cylinder', {
+        const baseColor = theme.archBaseColor;
+        const ringColor = selectColor(theme.archRingColors, index);
+        const accentColor = selectColor(theme.archAccentColors, index);
+
+        createEntity('a-cylinder', {
             radius: '0.28',
             height: arch.height,
-            color: '#495e84',
+            color: baseColor,
             position: `${arch.x - arch.width / 2} ${(arch.height / 2) - 1.2} ${arch.z - 2}`,
             material: 'shader: flat'
         }, root);
@@ -195,7 +587,7 @@ function addArches(root, densityLevel) {
         createEntity('a-cylinder', {
             radius: '0.28',
             height: arch.height,
-            color: '#495e84',
+            color: baseColor,
             position: `${arch.x + arch.width / 2} ${(arch.height / 2) - 1.2} ${arch.z - 2}`,
             material: 'shader: flat'
         }, root);
@@ -203,122 +595,67 @@ function addArches(root, densityLevel) {
         const archEl = createEntity('a-torus', {
             radius: arch.width / 2,
             radiusTubular: 0.18,
-            material: `shader: flat; color: ${arch.color}`,
+            material: `shader: flat; color: ${ringColor}`,
             rotation: '0 0 90',
             position: `${arch.x} ${(arch.height - 1.2)} ${arch.z - 2}`
         }, root);
 
-        archEl.setAttribute('animation__glow', `property: material.color; dir: alternate; dur: ${9000 + index * 1000}; easing: easeInOutSine; loop: true; to: ${arch.accent}`);
+        archEl.setAttribute('animation__glow', `property: material.color; dir: alternate; dur: ${9000 + index * 1000}; easing: easeInOutSine; loop: true; to: ${accentColor}`);
 
         createEntity('a-sphere', {
             radius: '0.3',
-            color: arch.accent,
+            color: accentColor,
             material: 'shader: flat; opacity: 0.9',
             position: `${arch.x} ${(arch.height - 1.2) + 0.2} ${arch.z - 2}`
         }, root);
     });
 }
 
-function addPillarClusters(root, densityLevel) {
-    const pillarConfigurations = [
-        { x: 12, z: -10, height: 24, width: 2.4, depth: 2.2, tone: '#6f84a3', accentColor: '#a2b9d8', baseColor: '#516482', glowColor: '#f0f6ff', minDensity: 'minimal' },
-        { x: -18, z: -4, height: 28, width: 2.8, depth: 2.4, tone: '#5f7a9a', accentColor: '#97b0d3', baseColor: '#445b78', glowColor: '#e4efff', minDensity: 'minimal' },
-        { x: 22, z: 12, height: 26, width: 2.2, depth: 2.8, tone: '#7d90ab', accentColor: '#b1c6e2', baseColor: '#586b88', glowColor: '#f6fbff', minDensity: 'standard' },
-        { x: -10, z: 18, height: 22, width: 2.1, depth: 2.1, tone: '#6a809d', accentColor: '#9cb2d1', baseColor: '#4b5f7a', glowColor: '#eff4ff', minDensity: 'standard' },
-        { x: 28, z: -22, height: 30, width: 2.6, depth: 2.4, tone: '#567190', accentColor: '#8ea7c9', baseColor: '#40526b', glowColor: '#e8f2ff', minDensity: 'rich' },
-        { x: -26, z: -18, height: 32, width: 3.2, depth: 2.6, tone: '#4f6a88', accentColor: '#89a3c4', baseColor: '#384c63', glowColor: '#e2ecff', minDensity: 'rich' },
-        { x: 16, z: 26, height: 36, width: 3.4, depth: 3.1, tone: '#627b99', accentColor: '#aac0dc', baseColor: '#495f7a', glowColor: '#f2f7ff', minDensity: 'immersive' },
-        { x: -30, z: 24, height: 34, width: 2.9, depth: 3.5, tone: '#556f8d', accentColor: '#96b2d3', baseColor: '#3e5169', glowColor: '#e9f3ff', minDensity: 'immersive' },
-        { x: 32, z: -6, height: 25, width: 2.5, depth: 3, tone: '#6d89a5', accentColor: '#a7bedc', baseColor: '#526680', glowColor: '#edf4ff', minDensity: 'immersive' },
-        { x: -14, z: 32, height: 29, width: 2.3, depth: 2.6, tone: '#5c7694', accentColor: '#95afd0', baseColor: '#435875', glowColor: '#e6f0ff', minDensity: 'immersive' }
-    ];
-
-    pillarConfigurations.forEach((pillar, index) => {
+function addPillarClusters(root, densityLevel, theme) {
+    PILLAR_CONFIGS.forEach((pillar, index) => {
         if (!isLevelAtLeast(densityLevel, pillar.minDensity)) {
             return;
         }
+
+        const bodyColor = selectColor(theme.pillarBodyColors, index);
+        const accentColor = selectColor(theme.pillarAccentColors, index);
+        const baseColor = darken(theme.pillarBaseColor, 0.05 * (index % 3));
+        const glowColor = theme.pillarGlowColor;
 
         const pillarGroup = createEntity('a-entity', {
             position: `${pillar.x} -1.2 ${pillar.z - 2}`
         }, root);
 
         createEntity('a-box', {
-            width: pillar.width.toFixed(2),
-            depth: pillar.depth.toFixed(2),
+            width: pillar.width,
+            depth: pillar.depth,
             height: pillar.height,
-            color: pillar.tone,
             position: `0 ${pillar.height / 2} 0`,
-            material: 'shader: flat'
+            color: bodyColor,
+            material: 'shader: flat; metalness: 0.18; roughness: 0.45'
         }, pillarGroup);
 
-        createEntity('a-cylinder', {
-            radius: (Math.max(pillar.width, pillar.depth) * 0.65).toFixed(2),
-            height: '0.6',
-            color: pillar.baseColor || '#607593',
-            material: 'shader: flat',
-            position: '0 0.3 0'
+        createEntity('a-box', {
+            width: (pillar.width * 0.6).toFixed(2),
+            depth: (pillar.depth * 0.6).toFixed(2),
+            height: (pillar.height * 0.5).toFixed(2),
+            position: `0 ${(pillar.height * 0.5) / 2 + pillar.height * 0.25} 0`,
+            color: accentColor,
+            material: 'shader: flat; opacity: 0.9'
         }, pillarGroup);
 
-        const accentHeights = pillar.accentRatios || [0.18, 0.42, 0.68, 0.92];
-        accentHeights.forEach((ratio) => {
-            createEntity('a-cylinder', {
-                radius: (Math.max(pillar.width, pillar.depth) * (0.42 + ratio * 0.12)).toFixed(2),
-                height: '0.2',
-                color: pillar.accentColor || '#9fb6cf',
-                material: 'shader: flat; opacity: 0.82',
-                position: `0 ${pillar.height * ratio} 0`
-            }, pillarGroup);
-        });
-
-        const ribWidth = Math.max(0.22, pillar.width * 0.22);
-        const ribDepth = Math.max(0.22, pillar.depth * 0.22);
-        const ribHeight = pillar.height * 0.7;
-        const ribYOffset = pillar.height * 0.25 + ribHeight / 2;
-        const surfaceInset = 0.04;
-        const halfWidth = pillar.width / 2;
-        const halfDepth = pillar.depth / 2;
-        const ribOffsets = [
-            { axis: 'x', direction: 1, width: ribWidth, depth: ribDepth * 0.6 },
-            { axis: 'x', direction: -1, width: ribWidth, depth: ribDepth * 0.6 },
-            { axis: 'z', direction: 1, width: ribDepth * 0.6, depth: ribDepth },
-            { axis: 'z', direction: -1, width: ribDepth * 0.6, depth: ribDepth }
-        ];
-
-        ribOffsets.forEach((offset) => {
-            const ribAttributes = {
-                width: offset.width.toFixed(2),
-                depth: offset.depth.toFixed(2),
-                height: ribHeight.toFixed(2),
-                color: '#4e6178',
-                material: 'shader: flat; opacity: 0.7; side: double'
-            };
-
-            if (offset.axis === 'x') {
-                const available = Math.max(0, halfWidth - offset.width / 2);
-                const inset = Math.min(available, surfaceInset);
-                const positionX = offset.direction * (available - inset);
-                ribAttributes.position = `${positionX.toFixed(2)} ${ribYOffset.toFixed(2)} 0`;
-            } else {
-                const available = Math.max(0, halfDepth - offset.depth / 2);
-                const inset = Math.min(available, surfaceInset);
-                const positionZ = offset.direction * (available - inset);
-                ribAttributes.position = `0 ${ribYOffset.toFixed(2)} ${positionZ.toFixed(2)}`;
-            }
-
-            createEntity('a-box', ribAttributes, pillarGroup);
-        });
-
-        createEntity('a-cylinder', {
-            radius: (Math.max(pillar.width, pillar.depth) * 0.6).toFixed(2),
-            height: '0.25',
-            color: pillar.accentColor || '#d4e0f2',
-            material: 'shader: flat; opacity: 0.9',
-            position: `0 ${pillar.height - 0.25} 0`
+        createEntity('a-box', {
+            width: (pillar.width * 0.9).toFixed(2),
+            depth: (pillar.depth * 0.9).toFixed(2),
+            height: '0.4',
+            position: `0 ${pillar.height + 0.2} 0`,
+            color: baseColor,
+            material: 'shader: flat; metalness: 0.25; roughness: 0.3'
         }, pillarGroup);
 
         createEntity('a-sphere', {
             radius: (Math.max(pillar.width, pillar.depth) * 0.35).toFixed(2),
-            color: pillar.glowColor || '#e4ebf6',
+            color: glowColor,
             material: 'shader: flat; opacity: 0.95',
             position: `0 ${pillar.height + 0.5} 0`,
             animation__pulse: `property: scale; dir: alternate; dur: ${6000 + index * 800}; easing: easeInOutSine; loop: true; to: 1.08 1.12 1.08`
@@ -326,57 +663,32 @@ function addPillarClusters(root, densityLevel) {
     });
 }
 
-function addFloatingPlatforms(root, densityLevel) {
-    if (!isLevelAtLeast(densityLevel, 'rich')) {
-        return;
-    }
-
-    const floatingPlatforms = [
-        { x: 6, y: -1, z: -10, scale: '2.4 0.12 2.4', hover: 0.4, phase: 0, color: '#c6d6e5' },
-        { x: -8, y: -0.5, z: -14, scale: '1.8 0.1 1.8', hover: 0.25, phase: 2000, color: '#b5cade' },
-        { x: 10, y: 1, z: 12, scale: '2 0.1 2', hover: 0.35, phase: 4000, color: '#c8dff5' },
-        { x: -4, y: 1.5, z: 18, scale: '1.4 0.08 2.6', hover: 0.2, phase: 1500, color: '#bcd0e6' },
-        { x: 12, y: 2.2, z: -6, scale: '1.6 0.12 1.6', hover: 0.28, phase: 3200, color: '#d0e2f6', minDensity: 'immersive' },
-        { x: -12, y: 2.8, z: 10, scale: '1.9 0.1 2.4', hover: 0.3, phase: 3800, color: '#d6e8fb', minDensity: 'immersive' }
-    ];
-
-    floatingPlatforms.forEach((platform) => {
-        if (platform.minDensity && !isLevelAtLeast(densityLevel, platform.minDensity)) {
+function addFloatingPlatforms(root, densityLevel, theme) {
+    FLOATING_PLATFORM_CONFIGS.forEach((platform, index) => {
+        if (!isLevelAtLeast(densityLevel, platform.minDensity)) {
             return;
         }
 
+        const color = selectColor(theme.floatingPlatformColors, index);
         const platformEl = createEntity('a-box', {
-            color: platform.color,
+            color,
             scale: platform.scale,
             position: `${platform.x} ${platform.y} ${platform.z}`,
             material: 'shader: flat'
         }, root);
 
-        platformEl.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${10000 + platform.phase}; easing: easeInOutSine; loop: true; to: ${platform.x} ${platform.y + platform.hover} ${platform.z}; delay: ${platform.phase}`);
+        platformEl.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${10000 + platform.delay}; easing: easeInOutSine; loop: true; to: ${platform.x} ${platform.y + platform.hover} ${platform.z}; delay: ${platform.delay}`);
     });
 }
 
-function addClouds(root, densityLevel) {
-    const baseClouds = [
-        { x: 8, y: 9, z: -12, scale: '3.2 1.4 1.4', delay: 0, drift: 3, minDensity: 'minimal' },
-        { x: -10, y: 10, z: 14, scale: '2.7 1.2 1.2', delay: 2000, drift: 2, minDensity: 'minimal' },
-        { x: -4, y: 8, z: -16, scale: '3.6 1.5 1.5', delay: 4000, drift: 4, minDensity: 'standard' },
-        { x: 14, y: 11, z: 22, scale: '4.2 1.8 1.8', delay: 6000, drift: 5, minDensity: 'standard' },
-        { x: 18, y: 12, z: -20, scale: '3.5 1.4 1.4', delay: 800, drift: 4, minDensity: 'rich' },
-        { x: -20, y: 13, z: 26, scale: '3.8 1.6 1.6', delay: 2400, drift: 3.5, minDensity: 'rich' },
-        { x: 6, y: 14, z: 30, scale: '4.6 1.8 1.8', delay: 5200, drift: 5.5, minDensity: 'immersive' },
-        { x: -16, y: 15, z: -28, scale: '5 1.9 1.9', delay: 1000, drift: 3.5, minDensity: 'immersive' },
-        { x: 18, y: 16, z: 30, scale: '5.2 1.9 1.9', delay: 2500, drift: 4.5, minDensity: 'immersive' },
-        { x: 4, y: 14, z: 26, scale: '3.8 1.5 1.5', delay: 4200, drift: 3, minDensity: 'immersive' }
-    ];
-
-    baseClouds.forEach((cloud) => {
+function addClouds(root, densityLevel, theme) {
+    CLOUD_CONFIGS.forEach((cloud, index) => {
         if (!isLevelAtLeast(densityLevel, cloud.minDensity)) {
             return;
         }
 
         const cloudEl = createEntity('a-sphere', {
-            color: '#ffffff',
+            color: theme.cloudColor,
             position: `${cloud.x} ${cloud.y} ${cloud.z}`,
             scale: cloud.scale,
             opacity: '0.85',
@@ -387,42 +699,24 @@ function addClouds(root, densityLevel) {
         cloudEl.setAttribute('animation__drift', `property: position; dir: alternate; dur: ${18000 + cloud.delay}; easing: easeInOutSine; loop: true; to: ${cloud.x + cloud.drift} ${cloud.y} ${cloud.z}; delay: ${cloud.delay / 2}`);
     });
 
-    if (isLevelAtLeast(densityLevel, 'standard')) {
-        const farCloudBands = [
-            { y: 4, from: -25, to: 25, z: -35, width: 40, delay: 0 },
-            { y: 9, from: 22, to: -18, z: 38, width: 36, delay: 4000 },
-            { y: 12, from: -32, to: 32, z: -42, width: 48, delay: 2600, minDensity: 'immersive' }
-        ];
+    FAR_CLOUD_BANDS.forEach((band) => {
+        if (band.minDensity && !isLevelAtLeast(densityLevel, band.minDensity)) {
+            return;
+        }
 
-        farCloudBands.forEach((band) => {
-            if (band.minDensity && !isLevelAtLeast(densityLevel, band.minDensity)) {
-                return;
-            }
-            createEntity('a-plane', {
-                width: `${band.width}`,
-                height: '6',
-                material: 'shader: flat; color: #ffffff; opacity: 0.18; side: double',
-                rotation: '0 0 0',
-                position: `0 ${band.y} ${band.z}`,
-                animation__wind: `property: position; dir: alternate; dur: 24000; easing: easeInOutSine; loop: true; to: ${band.to} ${band.y} ${band.z}; from: ${band.from} ${band.y} ${band.z}; delay: ${band.delay}`
-            }, root);
-        });
-    }
+        createEntity('a-plane', {
+            width: `${band.width}`,
+            height: '6',
+            material: `shader: flat; color: ${theme.cloudBandColor}; opacity: 0.18; side: double`,
+            rotation: '0 0 0',
+            position: `0 ${band.y} ${band.z}`,
+            animation__wind: `property: position; dir: alternate; dur: 24000; easing: easeInOutSine; loop: true; to: ${band.to} ${band.y} ${band.z}; from: ${band.from} ${band.y} ${band.z}; delay: ${band.delay}`
+        }, root);
+    });
 }
 
-function addWindTrails(root, densityLevel) {
-    if (!isLevelAtLeast(densityLevel, 'standard')) {
-        return;
-    }
-
-    const windTrails = [
-        { position: '-12 2 -22', rotation: '0 10 0', length: 14, minDensity: 'standard' },
-        { position: '16 3 28', rotation: '0 -20 0', length: 18, minDensity: 'standard' },
-        { position: '8 6 -16', rotation: '0 15 0', length: 12, minDensity: 'rich' },
-        { position: '-18 7 20', rotation: '0 -25 0', length: 16, minDensity: 'immersive' }
-    ];
-
-    windTrails.forEach((trail) => {
+function addWindTrails(root, densityLevel, theme) {
+    WIND_TRAIL_CONFIGS.forEach((trail) => {
         if (!isLevelAtLeast(densityLevel, trail.minDensity)) {
             return;
         }
@@ -430,7 +724,7 @@ function addWindTrails(root, densityLevel) {
         createEntity('a-plane', {
             width: `${trail.length}`,
             height: '1.6',
-            material: 'shader: flat; color: #b9ddff; opacity: 0.12; side: double',
+            material: `shader: flat; color: ${theme.windColor}; opacity: 0.12; side: double`,
             position: trail.position,
             rotation: trail.rotation,
             animation__pulse: 'property: material.opacity; dir: alternate; dur: 3500; easing: easeInOutSine; loop: true; to: 0.22'
@@ -438,26 +732,16 @@ function addWindTrails(root, densityLevel) {
     });
 }
 
-function addBalloons(root, densityLevel) {
-    if (!isLevelAtLeast(densityLevel, 'rich')) {
-        return;
-    }
-
-    const tetheredBalloons = [
-        { x: 20, y: 15, z: -30, color: '#ffcf66', bob: 1.6, delay: 0, minDensity: 'rich' },
-        { x: -24, y: 13, z: 34, color: '#8ed6ff', bob: 1.1, delay: 2200, minDensity: 'rich' },
-        { x: 10, y: 18, z: 18, color: '#ff9eb5', bob: 1.8, delay: 1800, minDensity: 'immersive' },
-        { x: -18, y: 17, z: -24, color: '#ffd3a4', bob: 1.4, delay: 1400, minDensity: 'immersive' }
-    ];
-
-    tetheredBalloons.forEach((balloon) => {
+function addBalloons(root, densityLevel, theme) {
+    BALLOON_CONFIGS.forEach((balloon, index) => {
         if (!isLevelAtLeast(densityLevel, balloon.minDensity)) {
             return;
         }
 
+        const color = selectColor(theme.balloonColors, index);
         createEntity('a-sphere', {
             radius: '1.5',
-            color: balloon.color,
+            color,
             position: `${balloon.x} ${balloon.y} ${balloon.z}`,
             material: 'shader: flat; opacity: 0.95',
             animation__bob: `property: position; dir: alternate; dur: ${9000 + balloon.delay}; easing: easeInOutSine; loop: true; to: ${balloon.x} ${balloon.y + balloon.bob} ${balloon.z}; delay: ${balloon.delay}`
@@ -466,28 +750,15 @@ function addBalloons(root, densityLevel) {
         createEntity('a-cylinder', {
             radius: '0.02',
             height: `${balloon.y + 3}`,
-            color: '#f9f1d0',
+            color: lighten(theme.balloonColors[0] || '#ffffff', 0.2),
             position: `${balloon.x} ${(balloon.y - 3) / 2} ${balloon.z}`,
             material: 'shader: flat; opacity: 0.6'
         }, root);
     });
 }
 
-function addTrees(root, densityLevel) {
-    const stylizedTrees = [
-        { x: 26, z: -14, trunkHeight: 3.2, canopyScale: '2.6 2.8 2.6', sway: 0.18, canopyColor: '#7ec87c', highlightColor: '#a8e0a2', minDensity: 'minimal' },
-        { x: -28, z: -10, trunkHeight: 4, canopyScale: '3 3.4 3', sway: 0.24, canopyColor: '#6fc47a', highlightColor: '#97de9f', minDensity: 'minimal' },
-        { x: 24, z: 18, trunkHeight: 3.6, canopyScale: '2.4 2.6 2.4', sway: 0.16, canopyColor: '#8cd290', highlightColor: '#b6e9b8', minDensity: 'standard' },
-        { x: -22, z: 22, trunkHeight: 3.8, canopyScale: '2.8 3 2.8', sway: 0.2, canopyColor: '#75c080', highlightColor: '#a6e0ae', minDensity: 'standard' },
-        { x: 30, z: 28, trunkHeight: 4.4, canopyScale: '2.2 2.4 2.2', sway: 0.14, canopyColor: '#82c88a', highlightColor: '#b2e3b7', minDensity: 'rich' },
-        { x: -34, z: 18, trunkHeight: 4.8, canopyScale: '2.6 2.9 2.6', sway: 0.22, canopyColor: '#6abd78', highlightColor: '#9ddc9f', minDensity: 'rich' },
-        { x: 20, z: -28, trunkHeight: 3.4, canopyScale: '2.3 2.5 2.3', sway: 0.17, canopyColor: '#78c684', highlightColor: '#a7e0b0', minDensity: 'immersive' },
-        { x: -26, z: -24, trunkHeight: 4.2, canopyScale: '2.9 3.1 2.9', sway: 0.19, canopyColor: '#89ce92', highlightColor: '#bce8c1', minDensity: 'immersive' },
-        { x: 16, z: 32, trunkHeight: 3.6, canopyScale: '2.4 2.5 2.4', sway: 0.21, canopyColor: '#7dd68f', highlightColor: '#adefc2', minDensity: 'immersive' },
-        { x: -32, z: 30, trunkHeight: 4.6, canopyScale: '2.8 3.2 2.8', sway: 0.2, canopyColor: '#6ccb7c', highlightColor: '#99ecaf', minDensity: 'immersive' }
-    ];
-
-    stylizedTrees.forEach((tree, index) => {
+function addTrees(root, densityLevel, theme) {
+    TREE_CONFIGS.forEach((tree, index) => {
         if (!isLevelAtLeast(densityLevel, tree.minDensity)) {
             return;
         }
@@ -500,90 +771,76 @@ function addTrees(root, densityLevel) {
             radius: '0.28',
             height: tree.trunkHeight,
             position: `0 ${tree.trunkHeight / 2} 0`,
-            color: '#6b4f2c',
+            color: theme.treeTrunkColor,
             material: 'shader: flat'
         }, treeGroup);
 
+        const canopyColor = selectColor(theme.treeCanopyColors, index);
         const canopy = createEntity('a-sphere', {
             position: `0 ${tree.trunkHeight + 0.8} 0`,
             scale: tree.canopyScale,
-            color: tree.canopyColor,
+            color: canopyColor,
             material: 'shader: flat; roughness: 0.7'
         }, treeGroup);
 
         canopy.setAttribute('animation__sway', `property: rotation; dir: alternate; dur: ${6000 + index * 1200}; easing: easeInOutSine; loop: true; to: ${tree.sway * 60} ${tree.sway * 80} ${tree.sway * -40}`);
 
+        const highlightColor = selectColor(theme.treeHighlightColors, index);
         createEntity('a-sphere', {
             position: `0 ${tree.trunkHeight + 0.8} 0`,
             scale: '1.2 0.8 1.2',
-            color: tree.highlightColor,
+            color: highlightColor,
             material: 'shader: flat; opacity: 0.4'
         }, treeGroup);
     });
 }
 
-function addMountainSilhouettes(root, densityLevel) {
-    if (!isLevelAtLeast(densityLevel, 'standard')) {
-        return;
-    }
-
-    const mountainConfigs = [
-        { x: 18, z: -32, height: 18, radius: 9, color: '#7286a0', minDensity: 'standard' },
-        { x: -22, z: -34, height: 19, radius: 10, color: '#6b7c96', minDensity: 'standard' },
-        { x: 26, z: 36, height: 20, radius: 11, color: '#7088a8', minDensity: 'rich' },
-        { x: -30, z: 32, height: 21, radius: 12, color: '#677d96', minDensity: 'rich' },
-        { x: 8, z: 40, height: 17, radius: 8, color: '#8097b2', minDensity: 'rich' },
-        { x: -8, z: -40, height: 22, radius: 10, color: '#647791', minDensity: 'immersive' },
-        { x: 34, z: -28, height: 23, radius: 12, color: '#5f7087', minDensity: 'immersive' },
-        { x: -36, z: 26, height: 24, radius: 13, color: '#5a6c82', minDensity: 'immersive' }
-    ];
-
-    mountainConfigs.forEach((mountain, index) => {
+function addMountainSilhouettes(root, densityLevel, theme) {
+    MOUNTAIN_CONFIGS.forEach((mountain, index) => {
         if (!isLevelAtLeast(densityLevel, mountain.minDensity)) {
             return;
         }
 
+        const mainColor = selectColor(theme.mountainMainColors, index);
+        const secondaryColor = selectColor(theme.mountainSecondaryColors, index);
+        const highlightColor = theme.mountainHighlightColor;
+
         createEntity('a-entity', {
             geometry: `primitive: cone; radiusBottom: ${mountain.radius}; radiusTop: 0.5; height: ${mountain.height}`,
             position: `${mountain.x} ${(mountain.height / 2) - 2} ${mountain.z - 2}`,
-            material: `shader: flat; color: ${mountain.color}; opacity: 0.85`
+            material: `shader: flat; color: ${mainColor}; opacity: 0.85`
         }, root);
 
         createEntity('a-entity', {
-            geometry: `primitive: cone; radiusBottom: ${mountain.radius * 0.6}; radiusTop: 0.2; height: ${mountain.height * 0.8}`,
+            geometry: `primitive: cone; radiusBottom: ${(mountain.radius * 0.6).toFixed(2)}; radiusTop: 0.2; height: ${(mountain.height * 0.8).toFixed(2)}`,
             position: `${mountain.x + 2} ${(mountain.height * 0.8) / 2 - 1.8} ${mountain.z - 5}`,
-            material: `shader: flat; color: #7f93ad; opacity: 0.75`
+            material: `shader: flat; color: ${secondaryColor}; opacity: 0.78`
         }, root);
 
         if (isLevelAtLeast(densityLevel, 'immersive')) {
             createEntity('a-plane', {
-                width: `${mountain.radius * 1.6}`,
+                width: `${(mountain.radius * 1.6).toFixed(2)}`,
                 height: '1.2',
                 position: `${mountain.x} ${(mountain.height / 2) + 1} ${mountain.z - 2}`,
                 rotation: '0 0 0',
-                material: 'shader: flat; color: #d9e6f5; opacity: 0.12',
+                material: `shader: flat; color: ${highlightColor}; opacity: 0.12`,
                 animation__shimmer: `property: material.opacity; dir: alternate; dur: ${7000 + index * 500}; easing: easeInOutSine; loop: true; to: 0.22`
             }, root);
         }
     });
 }
 
-function addSkyLanterns(root, densityLevel) {
+function addSkyLanterns(root, densityLevel, theme) {
     if (!isLevelAtLeast(densityLevel, 'immersive')) {
         return;
     }
 
-    const lanternConfigs = [
-        { x: 2, y: 12, z: -6, color: '#ffe08a', path: '2 12 -6, 3 14 -7, 2 13 -8' },
-        { x: -3, y: 13, z: -5, color: '#ffd1ff', path: '-3 13 -5, -2 14 -6, -3 12 -7' },
-        { x: 1, y: 11, z: -3, color: '#b5f0ff', path: '1 11 -3, 2 12 -2, 1 13 -1' }
-    ];
-
-    lanternConfigs.forEach((lantern, index) => {
+    LANTERN_CONFIGS.forEach((lantern, index) => {
+        const color = selectColor(theme.lanternColors, index);
         const lanternEl = createEntity('a-entity', {
             geometry: 'primitive: octahedron; radius: 0.4',
             position: `${lantern.x} ${lantern.y} ${lantern.z}`,
-            material: `shader: flat; color: ${lantern.color}; opacity: 0.85`
+            material: `shader: flat; color: ${color}; opacity: 0.85`
         }, root);
 
         lanternEl.setAttribute('animation__float', `property: position; dir: alternate; dur: ${8000 + index * 1500}; easing: easeInOutSine; loop: true; to: ${lantern.path.split(', ')[1]}`);
@@ -597,10 +854,13 @@ export const heightsDecorModule = {
     sceneEl: null,
     originalFog: null,
     currentDensity: 'immersive',
+    currentPalette: 'default',
+    currentTheme: getDefaultTheme(),
 
-    create(sceneEl, densityLevel = 'immersive') {
+    create(sceneEl, densityLevel = 'immersive', paletteKey = 'default') {
         this.sceneEl = sceneEl;
         this.currentDensity = DENSITY_LEVELS.includes(densityLevel) ? densityLevel : 'immersive';
+        this.currentPalette = paletteKey || 'default';
 
         if (!this.originalFog) {
             const currentFog = sceneEl.getAttribute('fog');
@@ -625,6 +885,21 @@ export const heightsDecorModule = {
         }
     },
 
+    updatePalette(paletteKey) {
+        const normalizedKey = paletteKey === 'auto' ? 'default' : (paletteKey || 'default');
+        if (this.currentPalette === normalizedKey) {
+            return;
+        }
+        this.currentPalette = normalizedKey;
+        if (this.sceneEl) {
+            this._rebuild();
+        }
+    },
+
+    getCurrentTheme() {
+        return this.currentTheme || getDefaultTheme();
+    },
+
     _rebuild() {
         if (!this.sceneEl) {
             return;
@@ -634,23 +909,25 @@ export const heightsDecorModule = {
             this.decorRoot.parentNode.removeChild(this.decorRoot);
         }
 
+        this.currentTheme = getThemeForPalette(this.currentPalette);
         this.decorRoot = createEntity('a-entity', { id: 'heights-decor-root' });
 
-        addBaseStructures(this.decorRoot);
-        addCloseTowerRing(this.decorRoot, this.currentDensity);
-        addHoveringWalkways(this.decorRoot, this.currentDensity);
-        addArches(this.decorRoot, this.currentDensity);
-        addPillarClusters(this.decorRoot, this.currentDensity);
-        addFloatingPlatforms(this.decorRoot, this.currentDensity);
-        addClouds(this.decorRoot, this.currentDensity);
-        addWindTrails(this.decorRoot, this.currentDensity);
-        addBalloons(this.decorRoot, this.currentDensity);
-        addTrees(this.decorRoot, this.currentDensity);
-        addMountainSilhouettes(this.decorRoot, this.currentDensity);
-        addSkyLanterns(this.decorRoot, this.currentDensity);
+        addBaseStructures(this.decorRoot, this.currentTheme);
+        addCloseTowerRing(this.decorRoot, this.currentDensity, this.currentTheme);
+        addMegaTowers(this.decorRoot, this.currentDensity, this.currentTheme);
+        addHoveringWalkways(this.decorRoot, this.currentDensity, this.currentTheme);
+        addArches(this.decorRoot, this.currentDensity, this.currentTheme);
+        addPillarClusters(this.decorRoot, this.currentDensity, this.currentTheme);
+        addFloatingPlatforms(this.decorRoot, this.currentDensity, this.currentTheme);
+        addClouds(this.decorRoot, this.currentDensity, this.currentTheme);
+        addWindTrails(this.decorRoot, this.currentDensity, this.currentTheme);
+        addBalloons(this.decorRoot, this.currentDensity, this.currentTheme);
+        addTrees(this.decorRoot, this.currentDensity, this.currentTheme);
+        addMountainSilhouettes(this.decorRoot, this.currentDensity, this.currentTheme);
+        addSkyLanterns(this.decorRoot, this.currentDensity, this.currentTheme);
 
         this.sceneEl.appendChild(this.decorRoot);
-        this.sceneEl.setAttribute('fog', 'type: exponential; color: #d6ecff; density: 0.018');
+        this.sceneEl.setAttribute('fog', `type: exponential; color: ${this.currentTheme.fogColor}; density: 0.018`);
     },
 
     cleanup() {
@@ -669,5 +946,7 @@ export const heightsDecorModule = {
         this.sceneEl = null;
         this.originalFog = null;
         this.currentDensity = 'immersive';
+        this.currentPalette = 'default';
+        this.currentTheme = getDefaultTheme();
     }
 };

--- a/visuals/decor_heights.js
+++ b/visuals/decor_heights.js
@@ -9,6 +9,8 @@ const CLOSE_TOWER_CONFIGS = [
     { x: -3.0, z: -5.4, height: 19, baseRadius: 0.75, width: 1.05, depth: 1.05, minDensity: 'minimal' },
     { x: 4.8, z: -2.8, height: 17, baseRadius: 0.72, width: 0.95, depth: 1.0, minDensity: 'minimal' },
     { x: -5.1, z: -2.6, height: 17.5, baseRadius: 0.72, width: 1.0, depth: 1.05, minDensity: 'minimal' },
+    { x: 2.8, z: 4.6, height: 18.5, baseRadius: 0.7, width: 1.05, depth: 1.0, minDensity: 'minimal' },
+    { x: -3.2, z: 4.4, height: 18.2, baseRadius: 0.7, width: 1.05, depth: 1.0, minDensity: 'minimal' },
     { x: 2.4, z: -6.8, height: 20, baseRadius: 0.82, width: 1.15, depth: 1.15, minDensity: 'standard' },
     { x: -2.2, z: -7.2, height: 21, baseRadius: 0.85, width: 1.2, depth: 1.2, minDensity: 'standard' },
     { x: 0.8, z: -3.6, height: 22, baseRadius: 0.9, width: 1.35, depth: 1.1, minDensity: 'rich' },
@@ -45,6 +47,7 @@ const ARCH_CONFIGS = [
 const PILLAR_CONFIGS = [
     { x: 12, z: -10, height: 24, width: 2.4, depth: 2.2, minDensity: 'minimal' },
     { x: -18, z: -4, height: 28, width: 2.8, depth: 2.4, minDensity: 'minimal' },
+    { x: 10, z: 16, height: 25, width: 2.2, depth: 2.4, minDensity: 'minimal' },
     { x: 22, z: 12, height: 26, width: 2.2, depth: 2.8, minDensity: 'standard' },
     { x: -10, z: 18, height: 22, width: 2.1, depth: 2.1, minDensity: 'standard' },
     { x: 28, z: -22, height: 30, width: 2.6, depth: 2.4, minDensity: 'rich' },
@@ -100,6 +103,7 @@ const BALLOON_CONFIGS = [
 const TREE_CONFIGS = [
     { x: 26, z: -14, trunkHeight: 3.2, canopyScale: '2.6 2.8 2.6', sway: 0.18, minDensity: 'minimal' },
     { x: -28, z: -10, trunkHeight: 4, canopyScale: '3 3.4 3', sway: 0.24, minDensity: 'minimal' },
+    { x: 20, z: 20, trunkHeight: 3.4, canopyScale: '2.4 2.6 2.4', sway: 0.16, minDensity: 'minimal' },
     { x: 24, z: 18, trunkHeight: 3.6, canopyScale: '2.4 2.6 2.4', sway: 0.16, minDensity: 'standard' },
     { x: -22, z: 22, trunkHeight: 3.8, canopyScale: '2.8 3 2.8', sway: 0.2, minDensity: 'standard' },
     { x: 30, z: 28, trunkHeight: 4.4, canopyScale: '2.2 2.4 2.2', sway: 0.14, minDensity: 'rich' },
@@ -111,15 +115,20 @@ const TREE_CONFIGS = [
 ];
 
 const MOUNTAIN_CONFIGS = [
-    { x: 18, z: -32, height: 22, radius: 12, minDensity: 'standard' },
-    { x: -14, z: -36, height: 26, radius: 13, minDensity: 'standard' },
-    { x: 26, z: 40, height: 28, radius: 14, minDensity: 'rich' },
-    { x: -30, z: 36, height: 30, radius: 16, minDensity: 'rich' },
-    { x: 10, z: 48, height: 24, radius: 11, minDensity: 'rich' },
-    { x: -6, z: -46, height: 30, radius: 14, minDensity: 'immersive' },
-    { x: 36, z: -32, height: 32, radius: 15, minDensity: 'immersive' },
-    { x: -38, z: 30, height: 34, radius: 16, minDensity: 'immersive' },
-    { x: 42, z: 44, height: 36, radius: 18, minDensity: 'immersive' }
+    { x: 16, z: -46, height: 30, radius: 14, snowHeightRatio: 0.28, snowRadiusRatio: 0.42, minDensity: 'minimal' },
+    { x: -18, z: 50, height: 32, radius: 15, snowHeightRatio: 0.3, snowRadiusRatio: 0.44, minDensity: 'minimal' },
+    { x: 18, z: -32, height: 22, radius: 12, snowHeightRatio: 0.25, snowRadiusRatio: 0.38, minDensity: 'standard' },
+    { x: -14, z: -36, height: 26, radius: 13, snowHeightRatio: 0.28, snowRadiusRatio: 0.4, minDensity: 'standard' },
+    { x: 0, z: -72, height: 46, radius: 20, snowHeightRatio: 0.34, snowRadiusRatio: 0.46, minDensity: 'standard' },
+    { x: 26, z: 40, height: 28, radius: 14, snowHeightRatio: 0.27, snowRadiusRatio: 0.42, minDensity: 'rich' },
+    { x: -30, z: 36, height: 30, radius: 16, snowHeightRatio: 0.28, snowRadiusRatio: 0.44, minDensity: 'rich' },
+    { x: 48, z: 68, height: 50, radius: 22, snowHeightRatio: 0.36, snowRadiusRatio: 0.48, minDensity: 'rich' },
+    { x: 10, z: 48, height: 24, radius: 11, snowHeightRatio: 0.24, snowRadiusRatio: 0.36, minDensity: 'rich' },
+    { x: -6, z: -46, height: 30, radius: 14, snowHeightRatio: 0.28, snowRadiusRatio: 0.4, minDensity: 'immersive' },
+    { x: 36, z: -32, height: 32, radius: 15, snowHeightRatio: 0.3, snowRadiusRatio: 0.42, minDensity: 'immersive' },
+    { x: -38, z: 30, height: 34, radius: 16, snowHeightRatio: 0.3, snowRadiusRatio: 0.45, minDensity: 'immersive' },
+    { x: 42, z: 44, height: 36, radius: 18, snowHeightRatio: 0.32, snowRadiusRatio: 0.46, minDensity: 'immersive' },
+    { x: -52, z: 64, height: 52, radius: 23, snowHeightRatio: 0.38, snowRadiusRatio: 0.5, minDensity: 'immersive' }
 ];
 
 const LANTERN_CONFIGS = [
@@ -182,6 +191,7 @@ function getDefaultTheme() {
         mountainMainColors: ['#7286a0', '#6b7c96', '#7088a8', '#677d96', '#8097b2', '#647791', '#5f7087', '#5a6c82', '#6d7c95'],
         mountainSecondaryColors: ['#7f93ad', '#7a8fa8', '#7d9ab4', '#7489a1', '#8499b7', '#72839b'],
         mountainHighlightColor: '#d9e6f5',
+        mountainSnowColor: '#f9fcff',
         lanternColors: ['#ffe08a', '#ffd1ff', '#b5f0ff']
     };
 }
@@ -230,6 +240,7 @@ function getMonochromeTheme() {
     theme.mountainMainColors = [mixColors(base, mid, 0.45), mixColors(base, mid, 0.5), mixColors(base, mid, 0.55)];
     theme.mountainSecondaryColors = [mixColors(base, mid, 0.35), mixColors(base, mid, 0.4)];
     theme.mountainHighlightColor = mixColors(accent, highlight, 0.5);
+    theme.mountainSnowColor = mixColors(highlight, '#ffffff', 0.5);
     theme.lanternColors = [mixColors(accent, highlight, 0.5), mixColors(mid, highlight, 0.5), mixColors(base, accent, 0.5)];
 
     return theme;
@@ -342,6 +353,7 @@ function buildThemeFromPalette(palette) {
         darken(quaternary, 0.25)
     ];
     theme.mountainHighlightColor = lighten(quinary, 0.7);
+    theme.mountainSnowColor = lighten(quinary, 0.92);
 
     theme.lanternColors = [
         lighten(accent, 0.85),
@@ -393,21 +405,21 @@ function selectColor(colors, index) {
 
 function addBaseStructures(root, theme) {
     createEntity('a-entity', {
-        geometry: 'primitive: circle; radius: 58; segments: 96',
+        geometry: 'primitive: circle; radius: 90; segments: 96',
         material: `shader: flat; roughness: 0.8; color: ${theme.groundPlaneColor}`,
         rotation: '-90 0 0',
         position: '0 -1.2 -2'
     }, root);
 
     createEntity('a-entity', {
-        geometry: 'primitive: torus; radius: 58; radiusTubular: 0.6; segmentsTubular: 32; segmentsRadial: 12',
+        geometry: 'primitive: torus; radius: 90; radiusTubular: 0.8; segmentsTubular: 48; segmentsRadial: 12',
         material: `color: ${theme.groundRingColor}; shader: flat; metalness: 0.05; roughness: 0.6`,
         rotation: '90 0 0',
         position: '0 -1.45 -2'
     }, root);
 
     theme.terracesColors.forEach((color, index) => {
-        const radius = [25, 18, 12][index] || 10;
+        const radius = [32, 24, 16][index] || 12;
         const y = [-4, -6.5, -9][index] || -11;
         createEntity('a-cylinder', {
             radius: radius.toString(),
@@ -804,6 +816,11 @@ function addMountainSilhouettes(root, densityLevel, theme) {
         const mainColor = selectColor(theme.mountainMainColors, index);
         const secondaryColor = selectColor(theme.mountainSecondaryColors, index);
         const highlightColor = theme.mountainHighlightColor;
+        const snowColor = theme.mountainSnowColor;
+        const snowHeightRatio = clamp01(mountain.snowHeightRatio ?? 0.28);
+        const snowRadiusRatio = clamp01(mountain.snowRadiusRatio ?? 0.4);
+        const snowHeight = Math.max(2, Math.min(mountain.height * 0.6, mountain.height * snowHeightRatio));
+        const snowRadius = Math.max(1.2, Math.min(mountain.radius * 0.7, mountain.radius * snowRadiusRatio));
 
         createEntity('a-entity', {
             geometry: `primitive: cone; radiusBottom: ${mountain.radius}; radiusTop: 0.5; height: ${mountain.height}`,
@@ -815,6 +832,12 @@ function addMountainSilhouettes(root, densityLevel, theme) {
             geometry: `primitive: cone; radiusBottom: ${(mountain.radius * 0.6).toFixed(2)}; radiusTop: 0.2; height: ${(mountain.height * 0.8).toFixed(2)}`,
             position: `${mountain.x + 2} ${(mountain.height * 0.8) / 2 - 1.8} ${mountain.z - 5}`,
             material: `shader: flat; color: ${secondaryColor}; opacity: 0.78`
+        }, root);
+
+        createEntity('a-entity', {
+            geometry: `primitive: cone; radiusBottom: ${snowRadius.toFixed(2)}; radiusTop: 0.05; height: ${snowHeight.toFixed(2)}`,
+            position: `${mountain.x} ${(mountain.height - (snowHeight / 2)) - 2} ${mountain.z - 2}`,
+            material: `shader: flat; color: ${snowColor}; opacity: 0.92`
         }, root);
 
         if (isLevelAtLeast(densityLevel, 'immersive')) {

--- a/visuals/decor_heights.js
+++ b/visuals/decor_heights.js
@@ -1,341 +1,658 @@
 /* /visuals/decor_heights.js */
 
+const DENSITY_LEVELS = ['minimal', 'standard', 'rich', 'immersive'];
+
+function isLevelAtLeast(currentLevel, requiredLevel) {
+    return DENSITY_LEVELS.indexOf(currentLevel) >= DENSITY_LEVELS.indexOf(requiredLevel);
+}
+
+function createEntity(tagName, attributes = {}, parent) {
+    const element = document.createElement(tagName);
+    Object.entries(attributes).forEach(([key, value]) => {
+        element.setAttribute(key, value);
+    });
+    if (parent) {
+        parent.appendChild(element);
+    }
+    return element;
+}
+
+function addBaseStructures(root) {
+    createEntity('a-entity', {
+        geometry: 'primitive: circle; radius: 58; segments: 96',
+        material: 'shader: flat; roughness: 0.8; color: #f0e3c0',
+        rotation: '-90 0 0',
+        position: '0 -1.2 -2'
+    }, root);
+
+    createEntity('a-entity', {
+        geometry: 'primitive: torus; radius: 58; radiusTubular: 0.6; segmentsTubular: 32; segmentsRadial: 12',
+        material: 'color: #d7c5a3; shader: flat; metalness: 0.05; roughness: 0.6',
+        rotation: '90 0 0',
+        position: '0 -1.45 -2'
+    }, root);
+
+    const terraces = [
+        { radius: 25, y: -4, color: '#d3d9dc' },
+        { radius: 18, y: -6.5, color: '#b9c6cf' },
+        { radius: 12, y: -9, color: '#9fb3c4' }
+    ];
+
+    terraces.forEach((terrace) => {
+        createEntity('a-cylinder', {
+            radius: terrace.radius,
+            height: '0.4',
+            color: terrace.color,
+            position: `0 ${terrace.y} -2`,
+            material: 'shader: flat'
+        }, root);
+    });
+
+    createEntity('a-cylinder', {
+        radius: '6',
+        height: '14',
+        color: '#1f2a44',
+        opacity: '0.85',
+        position: '0 -8.5 -2',
+        material: 'shader: flat'
+    }, root);
+}
+
+function addCloseTowerRing(root, densityLevel) {
+    const towerConfigs = [
+        { x: 3.5, z: -5, height: 16, bodyColor: '#ff9a9e', accent: '#ffe5ec', glow: '#fff3e6', minDensity: 'minimal' },
+        { x: -3.2, z: -5.2, height: 17, bodyColor: '#fad0c4', accent: '#ffeacb', glow: '#fffaf0', minDensity: 'minimal' },
+        { x: 5.2, z: -2.5, height: 15, bodyColor: '#f6abb6', accent: '#ffd3e1', glow: '#ffeef5', minDensity: 'minimal' },
+        { x: -5.4, z: -2.2, height: 15.5, bodyColor: '#ffb7c3', accent: '#ffe0ea', glow: '#fff3f8', minDensity: 'minimal' },
+        { x: 2.2, z: -7, height: 18.5, bodyColor: '#c3bef0', accent: '#dfd7ff', glow: '#f5f2ff', minDensity: 'standard' },
+        { x: -1.8, z: -7.4, height: 19, bodyColor: '#a3bffa', accent: '#cdd9ff', glow: '#f0f4ff', minDensity: 'standard' },
+        { x: 6.2, z: 0.2, height: 14, bodyColor: '#f8b195', accent: '#ffd4b8', glow: '#fff1e6', minDensity: 'rich' },
+        { x: -6.5, z: 0.4, height: 14.5, bodyColor: '#f67280', accent: '#ff9ba9', glow: '#ffdce3', minDensity: 'rich' },
+        { x: 4.2, z: 2.2, height: 13.8, bodyColor: '#99c1de', accent: '#c1ddf1', glow: '#e8f5ff', minDensity: 'immersive' },
+        { x: -4.4, z: 2.6, height: 14.2, bodyColor: '#9ad5ca', accent: '#c4ede1', glow: '#e7fff7', minDensity: 'immersive' }
+    ];
+
+    towerConfigs.forEach((tower, index) => {
+        if (!isLevelAtLeast(densityLevel, tower.minDensity)) {
+            return;
+        }
+
+        const group = createEntity('a-entity', {
+            position: `${tower.x} -1.15 ${tower.z - 2}`
+        }, root);
+
+        createEntity('a-cylinder', {
+            radius: '0.75',
+            height: '1.2',
+            color: '#3d4f6c',
+            position: '0 0.6 0',
+            material: 'shader: flat'
+        }, group);
+
+        createEntity('a-box', {
+            width: '1.05',
+            depth: '1.05',
+            height: tower.height,
+            position: `0 ${(tower.height / 2) + 1.2} 0`,
+            color: tower.bodyColor,
+            material: 'shader: flat; metalness: 0.12; roughness: 0.35'
+        }, group);
+
+        const ringRadius = 0.85;
+        for (let i = 0; i < 3; i += 1) {
+            const ringHeight = 2 + i * (tower.height / 3);
+            createEntity('a-torus', {
+                radius: ringRadius,
+                radiusTubular: 0.06,
+                material: `shader: flat; color: ${tower.accent}`,
+                rotation: '90 0 0',
+                position: `0 ${ringHeight + 1.2} 0`
+            }, group);
+        }
+
+        createEntity('a-sphere', {
+            radius: '0.9',
+            color: tower.glow,
+            material: 'shader: flat; opacity: 0.85',
+            position: `0 ${tower.height + 1.7} 0`,
+            animation__pulse: `property: scale; dir: alternate; dur: ${9000 + index * 650}; easing: easeInOutSine; loop: true; to: 1.1 1.18 1.1`
+        }, group);
+    });
+}
+
+function addHoveringWalkways(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'standard')) {
+        return;
+    }
+
+    const walkwayConfigs = [
+        { x: 0, y: 4.8, z: -4.6, width: 6, depth: 1.1, color: '#4a6fa3', minDensity: 'standard' },
+        { x: 0, y: 7.5, z: -4.6, width: 5, depth: 0.8, color: '#547bb5', minDensity: 'rich' },
+        { x: 0, y: 9.8, z: -4.6, width: 4, depth: 0.7, color: '#5f88c8', minDensity: 'immersive' }
+    ];
+
+    walkwayConfigs.forEach((walkway, index) => {
+        if (!isLevelAtLeast(densityLevel, walkway.minDensity)) {
+            return;
+        }
+
+        const platform = createEntity('a-box', {
+            width: walkway.width,
+            depth: walkway.depth,
+            height: '0.12',
+            position: `${walkway.x} ${walkway.y} ${walkway.z}`,
+            color: walkway.color,
+            material: 'shader: flat; metalness: 0.08; roughness: 0.45'
+        }, root);
+
+        createEntity('a-box', {
+            width: walkway.width + 0.4,
+            depth: '0.08',
+            height: '0.4',
+            position: `${walkway.x} ${walkway.y + 0.25} ${walkway.z + (walkway.depth / 2)}`,
+            color: '#c4d7ff',
+            material: 'shader: flat; opacity: 0.65'
+        }, root);
+
+        createEntity('a-box', {
+            width: walkway.width + 0.4,
+            depth: '0.08',
+            height: '0.4',
+            position: `${walkway.x} ${walkway.y + 0.25} ${walkway.z - (walkway.depth / 2)}`,
+            color: '#c4d7ff',
+            material: 'shader: flat; opacity: 0.65'
+        }, root);
+
+        platform.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${12000 + index * 1600}; easing: easeInOutSine; loop: true; to: ${walkway.x} ${walkway.y + 0.4} ${walkway.z}`);
+    });
+}
+
+function addArches(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'standard')) {
+        return;
+    }
+
+    const archConfigs = [
+        { x: 3.5, z: -4.6, height: 6.4, width: 3.2, color: '#aec5ff', accent: '#deecff', minDensity: 'standard' },
+        { x: -3.5, z: -4.6, height: 6.1, width: 3.4, color: '#bcd3ff', accent: '#e4f1ff', minDensity: 'standard' },
+        { x: 0, z: -7.8, height: 7.8, width: 4.5, color: '#9db4ff', accent: '#d4e2ff', minDensity: 'rich' },
+        { x: 0, z: -1.2, height: 5.5, width: 3.6, color: '#c2b5ff', accent: '#ebe5ff', minDensity: 'immersive' }
+    ];
+
+    archConfigs.forEach((arch, index) => {
+        if (!isLevelAtLeast(densityLevel, arch.minDensity)) {
+            return;
+        }
+
+        const baseLeft = createEntity('a-cylinder', {
+            radius: '0.28',
+            height: arch.height,
+            color: '#495e84',
+            position: `${arch.x - arch.width / 2} ${(arch.height / 2) - 1.2} ${arch.z - 2}`,
+            material: 'shader: flat'
+        }, root);
+
+        createEntity('a-cylinder', {
+            radius: '0.28',
+            height: arch.height,
+            color: '#495e84',
+            position: `${arch.x + arch.width / 2} ${(arch.height / 2) - 1.2} ${arch.z - 2}`,
+            material: 'shader: flat'
+        }, root);
+
+        const archEl = createEntity('a-torus', {
+            radius: arch.width / 2,
+            radiusTubular: 0.18,
+            material: `shader: flat; color: ${arch.color}`,
+            rotation: '0 0 90',
+            position: `${arch.x} ${(arch.height - 1.2)} ${arch.z - 2}`
+        }, root);
+
+        archEl.setAttribute('animation__glow', `property: material.color; dir: alternate; dur: ${9000 + index * 1000}; easing: easeInOutSine; loop: true; to: ${arch.accent}`);
+
+        createEntity('a-sphere', {
+            radius: '0.3',
+            color: arch.accent,
+            material: 'shader: flat; opacity: 0.9',
+            position: `${arch.x} ${(arch.height - 1.2) + 0.2} ${arch.z - 2}`
+        }, root);
+    });
+}
+
+function addPillarClusters(root, densityLevel) {
+    const pillarConfigurations = [
+        { x: 12, z: -10, height: 24, width: 2.4, depth: 2.2, tone: '#6f84a3', accentColor: '#a2b9d8', baseColor: '#516482', glowColor: '#f0f6ff', minDensity: 'minimal' },
+        { x: -18, z: -4, height: 28, width: 2.8, depth: 2.4, tone: '#5f7a9a', accentColor: '#97b0d3', baseColor: '#445b78', glowColor: '#e4efff', minDensity: 'minimal' },
+        { x: 22, z: 12, height: 26, width: 2.2, depth: 2.8, tone: '#7d90ab', accentColor: '#b1c6e2', baseColor: '#586b88', glowColor: '#f6fbff', minDensity: 'standard' },
+        { x: -10, z: 18, height: 22, width: 2.1, depth: 2.1, tone: '#6a809d', accentColor: '#9cb2d1', baseColor: '#4b5f7a', glowColor: '#eff4ff', minDensity: 'standard' },
+        { x: 28, z: -22, height: 30, width: 2.6, depth: 2.4, tone: '#567190', accentColor: '#8ea7c9', baseColor: '#40526b', glowColor: '#e8f2ff', minDensity: 'rich' },
+        { x: -26, z: -18, height: 32, width: 3.2, depth: 2.6, tone: '#4f6a88', accentColor: '#89a3c4', baseColor: '#384c63', glowColor: '#e2ecff', minDensity: 'rich' },
+        { x: 16, z: 26, height: 36, width: 3.4, depth: 3.1, tone: '#627b99', accentColor: '#aac0dc', baseColor: '#495f7a', glowColor: '#f2f7ff', minDensity: 'immersive' },
+        { x: -30, z: 24, height: 34, width: 2.9, depth: 3.5, tone: '#556f8d', accentColor: '#96b2d3', baseColor: '#3e5169', glowColor: '#e9f3ff', minDensity: 'immersive' },
+        { x: 32, z: -6, height: 25, width: 2.5, depth: 3, tone: '#6d89a5', accentColor: '#a7bedc', baseColor: '#526680', glowColor: '#edf4ff', minDensity: 'immersive' },
+        { x: -14, z: 32, height: 29, width: 2.3, depth: 2.6, tone: '#5c7694', accentColor: '#95afd0', baseColor: '#435875', glowColor: '#e6f0ff', minDensity: 'immersive' }
+    ];
+
+    pillarConfigurations.forEach((pillar, index) => {
+        if (!isLevelAtLeast(densityLevel, pillar.minDensity)) {
+            return;
+        }
+
+        const pillarGroup = createEntity('a-entity', {
+            position: `${pillar.x} -1.2 ${pillar.z - 2}`
+        }, root);
+
+        createEntity('a-box', {
+            width: pillar.width.toFixed(2),
+            depth: pillar.depth.toFixed(2),
+            height: pillar.height,
+            color: pillar.tone,
+            position: `0 ${pillar.height / 2} 0`,
+            material: 'shader: flat'
+        }, pillarGroup);
+
+        createEntity('a-cylinder', {
+            radius: (Math.max(pillar.width, pillar.depth) * 0.65).toFixed(2),
+            height: '0.6',
+            color: pillar.baseColor || '#607593',
+            material: 'shader: flat',
+            position: '0 0.3 0'
+        }, pillarGroup);
+
+        const accentHeights = pillar.accentRatios || [0.18, 0.42, 0.68, 0.92];
+        accentHeights.forEach((ratio) => {
+            createEntity('a-cylinder', {
+                radius: (Math.max(pillar.width, pillar.depth) * (0.42 + ratio * 0.12)).toFixed(2),
+                height: '0.2',
+                color: pillar.accentColor || '#9fb6cf',
+                material: 'shader: flat; opacity: 0.82',
+                position: `0 ${pillar.height * ratio} 0`
+            }, pillarGroup);
+        });
+
+        const ribWidth = Math.max(0.22, pillar.width * 0.22);
+        const ribDepth = Math.max(0.22, pillar.depth * 0.22);
+        const ribHeight = pillar.height * 0.7;
+        const ribYOffset = pillar.height * 0.25 + ribHeight / 2;
+        const surfaceInset = 0.04;
+        const halfWidth = pillar.width / 2;
+        const halfDepth = pillar.depth / 2;
+        const ribOffsets = [
+            { axis: 'x', direction: 1, width: ribWidth, depth: ribDepth * 0.6 },
+            { axis: 'x', direction: -1, width: ribWidth, depth: ribDepth * 0.6 },
+            { axis: 'z', direction: 1, width: ribDepth * 0.6, depth: ribDepth },
+            { axis: 'z', direction: -1, width: ribDepth * 0.6, depth: ribDepth }
+        ];
+
+        ribOffsets.forEach((offset) => {
+            const ribAttributes = {
+                width: offset.width.toFixed(2),
+                depth: offset.depth.toFixed(2),
+                height: ribHeight.toFixed(2),
+                color: '#4e6178',
+                material: 'shader: flat; opacity: 0.7; side: double'
+            };
+
+            if (offset.axis === 'x') {
+                const available = Math.max(0, halfWidth - offset.width / 2);
+                const inset = Math.min(available, surfaceInset);
+                const positionX = offset.direction * (available - inset);
+                ribAttributes.position = `${positionX.toFixed(2)} ${ribYOffset.toFixed(2)} 0`;
+            } else {
+                const available = Math.max(0, halfDepth - offset.depth / 2);
+                const inset = Math.min(available, surfaceInset);
+                const positionZ = offset.direction * (available - inset);
+                ribAttributes.position = `0 ${ribYOffset.toFixed(2)} ${positionZ.toFixed(2)}`;
+            }
+
+            createEntity('a-box', ribAttributes, pillarGroup);
+        });
+
+        createEntity('a-cylinder', {
+            radius: (Math.max(pillar.width, pillar.depth) * 0.6).toFixed(2),
+            height: '0.25',
+            color: pillar.accentColor || '#d4e0f2',
+            material: 'shader: flat; opacity: 0.9',
+            position: `0 ${pillar.height - 0.25} 0`
+        }, pillarGroup);
+
+        createEntity('a-sphere', {
+            radius: (Math.max(pillar.width, pillar.depth) * 0.35).toFixed(2),
+            color: pillar.glowColor || '#e4ebf6',
+            material: 'shader: flat; opacity: 0.95',
+            position: `0 ${pillar.height + 0.5} 0`,
+            animation__pulse: `property: scale; dir: alternate; dur: ${6000 + index * 800}; easing: easeInOutSine; loop: true; to: 1.08 1.12 1.08`
+        }, pillarGroup);
+    });
+}
+
+function addFloatingPlatforms(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'rich')) {
+        return;
+    }
+
+    const floatingPlatforms = [
+        { x: 6, y: -1, z: -10, scale: '2.4 0.12 2.4', hover: 0.4, phase: 0, color: '#c6d6e5' },
+        { x: -8, y: -0.5, z: -14, scale: '1.8 0.1 1.8', hover: 0.25, phase: 2000, color: '#b5cade' },
+        { x: 10, y: 1, z: 12, scale: '2 0.1 2', hover: 0.35, phase: 4000, color: '#c8dff5' },
+        { x: -4, y: 1.5, z: 18, scale: '1.4 0.08 2.6', hover: 0.2, phase: 1500, color: '#bcd0e6' },
+        { x: 12, y: 2.2, z: -6, scale: '1.6 0.12 1.6', hover: 0.28, phase: 3200, color: '#d0e2f6', minDensity: 'immersive' },
+        { x: -12, y: 2.8, z: 10, scale: '1.9 0.1 2.4', hover: 0.3, phase: 3800, color: '#d6e8fb', minDensity: 'immersive' }
+    ];
+
+    floatingPlatforms.forEach((platform) => {
+        if (platform.minDensity && !isLevelAtLeast(densityLevel, platform.minDensity)) {
+            return;
+        }
+
+        const platformEl = createEntity('a-box', {
+            color: platform.color,
+            scale: platform.scale,
+            position: `${platform.x} ${platform.y} ${platform.z}`,
+            material: 'shader: flat'
+        }, root);
+
+        platformEl.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${10000 + platform.phase}; easing: easeInOutSine; loop: true; to: ${platform.x} ${platform.y + platform.hover} ${platform.z}; delay: ${platform.phase}`);
+    });
+}
+
+function addClouds(root, densityLevel) {
+    const baseClouds = [
+        { x: 8, y: 9, z: -12, scale: '3.2 1.4 1.4', delay: 0, drift: 3, minDensity: 'minimal' },
+        { x: -10, y: 10, z: 14, scale: '2.7 1.2 1.2', delay: 2000, drift: 2, minDensity: 'minimal' },
+        { x: -4, y: 8, z: -16, scale: '3.6 1.5 1.5', delay: 4000, drift: 4, minDensity: 'standard' },
+        { x: 14, y: 11, z: 22, scale: '4.2 1.8 1.8', delay: 6000, drift: 5, minDensity: 'standard' },
+        { x: 18, y: 12, z: -20, scale: '3.5 1.4 1.4', delay: 800, drift: 4, minDensity: 'rich' },
+        { x: -20, y: 13, z: 26, scale: '3.8 1.6 1.6', delay: 2400, drift: 3.5, minDensity: 'rich' },
+        { x: 6, y: 14, z: 30, scale: '4.6 1.8 1.8', delay: 5200, drift: 5.5, minDensity: 'immersive' },
+        { x: -16, y: 15, z: -28, scale: '5 1.9 1.9', delay: 1000, drift: 3.5, minDensity: 'immersive' },
+        { x: 18, y: 16, z: 30, scale: '5.2 1.9 1.9', delay: 2500, drift: 4.5, minDensity: 'immersive' },
+        { x: 4, y: 14, z: 26, scale: '3.8 1.5 1.5', delay: 4200, drift: 3, minDensity: 'immersive' }
+    ];
+
+    baseClouds.forEach((cloud) => {
+        if (!isLevelAtLeast(densityLevel, cloud.minDensity)) {
+            return;
+        }
+
+        const cloudEl = createEntity('a-sphere', {
+            color: '#ffffff',
+            position: `${cloud.x} ${cloud.y} ${cloud.z}`,
+            scale: cloud.scale,
+            opacity: '0.85',
+            material: 'shader: flat'
+        }, root);
+
+        cloudEl.setAttribute('animation__float', `property: position; dir: alternate; dur: ${12000 + cloud.delay}; easing: easeInOutSine; loop: true; to: ${cloud.x} ${cloud.y + 0.8} ${cloud.z}; delay: ${cloud.delay}`);
+        cloudEl.setAttribute('animation__drift', `property: position; dir: alternate; dur: ${18000 + cloud.delay}; easing: easeInOutSine; loop: true; to: ${cloud.x + cloud.drift} ${cloud.y} ${cloud.z}; delay: ${cloud.delay / 2}`);
+    });
+
+    if (isLevelAtLeast(densityLevel, 'standard')) {
+        const farCloudBands = [
+            { y: 4, from: -25, to: 25, z: -35, width: 40, delay: 0 },
+            { y: 9, from: 22, to: -18, z: 38, width: 36, delay: 4000 },
+            { y: 12, from: -32, to: 32, z: -42, width: 48, delay: 2600, minDensity: 'immersive' }
+        ];
+
+        farCloudBands.forEach((band) => {
+            if (band.minDensity && !isLevelAtLeast(densityLevel, band.minDensity)) {
+                return;
+            }
+            createEntity('a-plane', {
+                width: `${band.width}`,
+                height: '6',
+                material: 'shader: flat; color: #ffffff; opacity: 0.18; side: double',
+                rotation: '0 0 0',
+                position: `0 ${band.y} ${band.z}`,
+                animation__wind: `property: position; dir: alternate; dur: 24000; easing: easeInOutSine; loop: true; to: ${band.to} ${band.y} ${band.z}; from: ${band.from} ${band.y} ${band.z}; delay: ${band.delay}`
+            }, root);
+        });
+    }
+}
+
+function addWindTrails(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'standard')) {
+        return;
+    }
+
+    const windTrails = [
+        { position: '-12 2 -22', rotation: '0 10 0', length: 14, minDensity: 'standard' },
+        { position: '16 3 28', rotation: '0 -20 0', length: 18, minDensity: 'standard' },
+        { position: '8 6 -16', rotation: '0 15 0', length: 12, minDensity: 'rich' },
+        { position: '-18 7 20', rotation: '0 -25 0', length: 16, minDensity: 'immersive' }
+    ];
+
+    windTrails.forEach((trail) => {
+        if (!isLevelAtLeast(densityLevel, trail.minDensity)) {
+            return;
+        }
+
+        createEntity('a-plane', {
+            width: `${trail.length}`,
+            height: '1.6',
+            material: 'shader: flat; color: #b9ddff; opacity: 0.12; side: double',
+            position: trail.position,
+            rotation: trail.rotation,
+            animation__pulse: 'property: material.opacity; dir: alternate; dur: 3500; easing: easeInOutSine; loop: true; to: 0.22'
+        }, root);
+    });
+}
+
+function addBalloons(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'rich')) {
+        return;
+    }
+
+    const tetheredBalloons = [
+        { x: 20, y: 15, z: -30, color: '#ffcf66', bob: 1.6, delay: 0, minDensity: 'rich' },
+        { x: -24, y: 13, z: 34, color: '#8ed6ff', bob: 1.1, delay: 2200, minDensity: 'rich' },
+        { x: 10, y: 18, z: 18, color: '#ff9eb5', bob: 1.8, delay: 1800, minDensity: 'immersive' },
+        { x: -18, y: 17, z: -24, color: '#ffd3a4', bob: 1.4, delay: 1400, minDensity: 'immersive' }
+    ];
+
+    tetheredBalloons.forEach((balloon) => {
+        if (!isLevelAtLeast(densityLevel, balloon.minDensity)) {
+            return;
+        }
+
+        createEntity('a-sphere', {
+            radius: '1.5',
+            color: balloon.color,
+            position: `${balloon.x} ${balloon.y} ${balloon.z}`,
+            material: 'shader: flat; opacity: 0.95',
+            animation__bob: `property: position; dir: alternate; dur: ${9000 + balloon.delay}; easing: easeInOutSine; loop: true; to: ${balloon.x} ${balloon.y + balloon.bob} ${balloon.z}; delay: ${balloon.delay}`
+        }, root);
+
+        createEntity('a-cylinder', {
+            radius: '0.02',
+            height: `${balloon.y + 3}`,
+            color: '#f9f1d0',
+            position: `${balloon.x} ${(balloon.y - 3) / 2} ${balloon.z}`,
+            material: 'shader: flat; opacity: 0.6'
+        }, root);
+    });
+}
+
+function addTrees(root, densityLevel) {
+    const stylizedTrees = [
+        { x: 26, z: -14, trunkHeight: 3.2, canopyScale: '2.6 2.8 2.6', sway: 0.18, canopyColor: '#7ec87c', highlightColor: '#a8e0a2', minDensity: 'minimal' },
+        { x: -28, z: -10, trunkHeight: 4, canopyScale: '3 3.4 3', sway: 0.24, canopyColor: '#6fc47a', highlightColor: '#97de9f', minDensity: 'minimal' },
+        { x: 24, z: 18, trunkHeight: 3.6, canopyScale: '2.4 2.6 2.4', sway: 0.16, canopyColor: '#8cd290', highlightColor: '#b6e9b8', minDensity: 'standard' },
+        { x: -22, z: 22, trunkHeight: 3.8, canopyScale: '2.8 3 2.8', sway: 0.2, canopyColor: '#75c080', highlightColor: '#a6e0ae', minDensity: 'standard' },
+        { x: 30, z: 28, trunkHeight: 4.4, canopyScale: '2.2 2.4 2.2', sway: 0.14, canopyColor: '#82c88a', highlightColor: '#b2e3b7', minDensity: 'rich' },
+        { x: -34, z: 18, trunkHeight: 4.8, canopyScale: '2.6 2.9 2.6', sway: 0.22, canopyColor: '#6abd78', highlightColor: '#9ddc9f', minDensity: 'rich' },
+        { x: 20, z: -28, trunkHeight: 3.4, canopyScale: '2.3 2.5 2.3', sway: 0.17, canopyColor: '#78c684', highlightColor: '#a7e0b0', minDensity: 'immersive' },
+        { x: -26, z: -24, trunkHeight: 4.2, canopyScale: '2.9 3.1 2.9', sway: 0.19, canopyColor: '#89ce92', highlightColor: '#bce8c1', minDensity: 'immersive' },
+        { x: 16, z: 32, trunkHeight: 3.6, canopyScale: '2.4 2.5 2.4', sway: 0.21, canopyColor: '#7dd68f', highlightColor: '#adefc2', minDensity: 'immersive' },
+        { x: -32, z: 30, trunkHeight: 4.6, canopyScale: '2.8 3.2 2.8', sway: 0.2, canopyColor: '#6ccb7c', highlightColor: '#99ecaf', minDensity: 'immersive' }
+    ];
+
+    stylizedTrees.forEach((tree, index) => {
+        if (!isLevelAtLeast(densityLevel, tree.minDensity)) {
+            return;
+        }
+
+        const treeGroup = createEntity('a-entity', {
+            position: `${tree.x} -1.2 ${tree.z - 2}`
+        }, root);
+
+        createEntity('a-cylinder', {
+            radius: '0.28',
+            height: tree.trunkHeight,
+            position: `0 ${tree.trunkHeight / 2} 0`,
+            color: '#6b4f2c',
+            material: 'shader: flat'
+        }, treeGroup);
+
+        const canopy = createEntity('a-sphere', {
+            position: `0 ${tree.trunkHeight + 0.8} 0`,
+            scale: tree.canopyScale,
+            color: tree.canopyColor,
+            material: 'shader: flat; roughness: 0.7'
+        }, treeGroup);
+
+        canopy.setAttribute('animation__sway', `property: rotation; dir: alternate; dur: ${6000 + index * 1200}; easing: easeInOutSine; loop: true; to: ${tree.sway * 60} ${tree.sway * 80} ${tree.sway * -40}`);
+
+        createEntity('a-sphere', {
+            position: `0 ${tree.trunkHeight + 0.8} 0`,
+            scale: '1.2 0.8 1.2',
+            color: tree.highlightColor,
+            material: 'shader: flat; opacity: 0.4'
+        }, treeGroup);
+    });
+}
+
+function addMountainSilhouettes(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'standard')) {
+        return;
+    }
+
+    const mountainConfigs = [
+        { x: 18, z: -32, height: 18, radius: 9, color: '#7286a0', minDensity: 'standard' },
+        { x: -22, z: -34, height: 19, radius: 10, color: '#6b7c96', minDensity: 'standard' },
+        { x: 26, z: 36, height: 20, radius: 11, color: '#7088a8', minDensity: 'rich' },
+        { x: -30, z: 32, height: 21, radius: 12, color: '#677d96', minDensity: 'rich' },
+        { x: 8, z: 40, height: 17, radius: 8, color: '#8097b2', minDensity: 'rich' },
+        { x: -8, z: -40, height: 22, radius: 10, color: '#647791', minDensity: 'immersive' },
+        { x: 34, z: -28, height: 23, radius: 12, color: '#5f7087', minDensity: 'immersive' },
+        { x: -36, z: 26, height: 24, radius: 13, color: '#5a6c82', minDensity: 'immersive' }
+    ];
+
+    mountainConfigs.forEach((mountain, index) => {
+        if (!isLevelAtLeast(densityLevel, mountain.minDensity)) {
+            return;
+        }
+
+        createEntity('a-entity', {
+            geometry: `primitive: cone; radiusBottom: ${mountain.radius}; radiusTop: 0.5; height: ${mountain.height}`,
+            position: `${mountain.x} ${(mountain.height / 2) - 2} ${mountain.z - 2}`,
+            material: `shader: flat; color: ${mountain.color}; opacity: 0.85`
+        }, root);
+
+        createEntity('a-entity', {
+            geometry: `primitive: cone; radiusBottom: ${mountain.radius * 0.6}; radiusTop: 0.2; height: ${mountain.height * 0.8}`,
+            position: `${mountain.x + 2} ${(mountain.height * 0.8) / 2 - 1.8} ${mountain.z - 5}`,
+            material: `shader: flat; color: #7f93ad; opacity: 0.75`
+        }, root);
+
+        if (isLevelAtLeast(densityLevel, 'immersive')) {
+            createEntity('a-plane', {
+                width: `${mountain.radius * 1.6}`,
+                height: '1.2',
+                position: `${mountain.x} ${(mountain.height / 2) + 1} ${mountain.z - 2}`,
+                rotation: '0 0 0',
+                material: 'shader: flat; color: #d9e6f5; opacity: 0.12',
+                animation__shimmer: `property: material.opacity; dir: alternate; dur: ${7000 + index * 500}; easing: easeInOutSine; loop: true; to: 0.22`
+            }, root);
+        }
+    });
+}
+
+function addSkyLanterns(root, densityLevel) {
+    if (!isLevelAtLeast(densityLevel, 'immersive')) {
+        return;
+    }
+
+    const lanternConfigs = [
+        { x: 2, y: 12, z: -6, color: '#ffe08a', path: '2 12 -6, 3 14 -7, 2 13 -8' },
+        { x: -3, y: 13, z: -5, color: '#ffd1ff', path: '-3 13 -5, -2 14 -6, -3 12 -7' },
+        { x: 1, y: 11, z: -3, color: '#b5f0ff', path: '1 11 -3, 2 12 -2, 1 13 -1' }
+    ];
+
+    lanternConfigs.forEach((lantern, index) => {
+        const lanternEl = createEntity('a-entity', {
+            geometry: 'primitive: octahedron; radius: 0.4',
+            position: `${lantern.x} ${lantern.y} ${lantern.z}`,
+            material: `shader: flat; color: ${lantern.color}; opacity: 0.85`
+        }, root);
+
+        lanternEl.setAttribute('animation__float', `property: position; dir: alternate; dur: ${8000 + index * 1500}; easing: easeInOutSine; loop: true; to: ${lantern.path.split(', ')[1]}`);
+        lanternEl.setAttribute('animation__twirl', `property: rotation; dir: alternate; dur: ${6000 + index * 700}; easing: easeInOutSine; loop: true; to: 0 ${180 + index * 60} 0`);
+    });
+}
+
 export const heightsDecorModule = {
 
     decorRoot: null,
     sceneEl: null,
     originalFog: null,
+    currentDensity: 'immersive',
 
-    /**
-     * Crée un décor stylisé avec plusieurs plans et volumes pour suggérer la hauteur.
-     * @param {Element} sceneEl - L'élément <a-scene>.
-     */
-    create(sceneEl) {
-        if (this.decorRoot) {
+    create(sceneEl, densityLevel = 'immersive') {
+        this.sceneEl = sceneEl;
+        this.currentDensity = DENSITY_LEVELS.includes(densityLevel) ? densityLevel : 'immersive';
+
+        if (!this.originalFog) {
+            const currentFog = sceneEl.getAttribute('fog');
+            this.originalFog = currentFog ? { ...currentFog } : null;
+        }
+
+        this._rebuild();
+    },
+
+    updateDensity(newDensity) {
+        if (!DENSITY_LEVELS.includes(newDensity)) {
             return;
         }
 
-        this.sceneEl = sceneEl;
+        if (this.currentDensity === newDensity) {
+            return;
+        }
 
-        const currentFog = sceneEl.getAttribute('fog');
-        this.originalFog = currentFog ? { ...currentFog } : null;
-
-        this.decorRoot = document.createElement('a-entity');
-        this.decorRoot.setAttribute('id', 'heights-decor-root');
-
-        // Plateau principal sous la plateforme
-        const mainPlate = document.createElement('a-entity');
-        mainPlate.setAttribute('geometry', 'primitive: circle; radius: 58; segments: 96');
-        mainPlate.setAttribute('material', 'shader: flat; roughness: 0.8; color: #f0e3c0');
-        mainPlate.setAttribute('rotation', '-90 0 0');
-        mainPlate.setAttribute('position', '0 -1.2 -2');
-        this.decorRoot.appendChild(mainPlate);
-
-        const plateRim = document.createElement('a-entity');
-        plateRim.setAttribute('geometry', 'primitive: torus; radius: 58; radiusTubular: 0.6; segmentsTubular: 32; segmentsRadial: 12');
-        plateRim.setAttribute('material', 'color: #d7c5a3; shader: flat; metalness: 0.05; roughness: 0.6');
-        plateRim.setAttribute('rotation', '90 0 0');
-        plateRim.setAttribute('position', '0 -1.45 -2');
-        this.decorRoot.appendChild(plateRim);
-
-        // Terrasses inférieures pour créer de la profondeur
-        const terraces = [
-            { radius: 25, y: -4, color: '#d3d9dc' },
-            { radius: 18, y: -6.5, color: '#b9c6cf' },
-            { radius: 12, y: -9, color: '#9fb3c4' }
-        ];
-
-        terraces.forEach((terrace) => {
-            const terraceEl = document.createElement('a-cylinder');
-            terraceEl.setAttribute('radius', terrace.radius);
-            terraceEl.setAttribute('height', '0.4');
-            terraceEl.setAttribute('color', terrace.color);
-            terraceEl.setAttribute('position', `0 ${terrace.y} -2`);
-            terraceEl.setAttribute('material', 'shader: flat');
-            this.decorRoot.appendChild(terraceEl);
-        });
-
-        // Puits central sombre pour accentuer la sensation de hauteur
-        const depthWell = document.createElement('a-cylinder');
-        depthWell.setAttribute('radius', '6');
-        depthWell.setAttribute('height', '14');
-        depthWell.setAttribute('color', '#1f2a44');
-        depthWell.setAttribute('opacity', '0.85');
-        depthWell.setAttribute('position', '0 -8.5 -2');
-        depthWell.setAttribute('material', 'shader: flat');
-        this.decorRoot.appendChild(depthWell);
-
-        // Piliers stylisés placés à différentes distances
-        const pillarConfigurations = [
-            { x: 12, z: -10, height: 24, width: 2.4, depth: 2.2, tone: '#6f84a3', accentColor: '#a2b9d8', baseColor: '#516482', glowColor: '#f0f6ff' },
-            { x: -18, z: -4, height: 28, width: 2.8, depth: 2.4, tone: '#5f7a9a', accentColor: '#97b0d3', baseColor: '#445b78', glowColor: '#e4efff' },
-            { x: 22, z: 12, height: 26, width: 2.2, depth: 2.8, tone: '#7d90ab', accentColor: '#b1c6e2', baseColor: '#586b88', glowColor: '#f6fbff' },
-            { x: -10, z: 18, height: 22, width: 2.1, depth: 2.1, tone: '#6a809d', accentColor: '#9cb2d1', baseColor: '#4b5f7a', glowColor: '#eff4ff' },
-            { x: 28, z: -22, height: 30, width: 2.6, depth: 2.4, tone: '#567190', accentColor: '#8ea7c9', baseColor: '#40526b', glowColor: '#e8f2ff' },
-            { x: -26, z: -18, height: 32, width: 3.2, depth: 2.6, tone: '#4f6a88', accentColor: '#89a3c4', baseColor: '#384c63', glowColor: '#e2ecff' },
-            { x: 16, z: 26, height: 36, width: 3.4, depth: 3.1, tone: '#627b99', accentColor: '#aac0dc', baseColor: '#495f7a', glowColor: '#f2f7ff' },
-            { x: -30, z: 24, height: 34, width: 2.9, depth: 3.5, tone: '#556f8d', accentColor: '#96b2d3', baseColor: '#3e5169', glowColor: '#e9f3ff' },
-            { x: 32, z: -6, height: 25, width: 2.5, depth: 3, tone: '#6d89a5', accentColor: '#a7bedc', baseColor: '#526680', glowColor: '#edf4ff' },
-            { x: -14, z: 32, height: 29, width: 2.3, depth: 2.6, tone: '#5c7694', accentColor: '#95afd0', baseColor: '#435875', glowColor: '#e6f0ff' }
-        ];
-
-        pillarConfigurations.forEach((pillar, index) => {
-            const pillarGroup = document.createElement('a-entity');
-            pillarGroup.setAttribute('position', `${pillar.x} -1.2 ${pillar.z - 2}`);
-
-            const pillarCore = document.createElement('a-box');
-            pillarCore.setAttribute('width', pillar.width.toFixed(2));
-            pillarCore.setAttribute('depth', pillar.depth.toFixed(2));
-            pillarCore.setAttribute('height', pillar.height);
-            pillarCore.setAttribute('color', pillar.tone);
-            pillarCore.setAttribute('position', `0 ${pillar.height / 2} 0`);
-            pillarCore.setAttribute('material', 'shader: flat');
-            pillarCore.setAttribute('animation__glow', `property: material.color; dir: alternate; dur: ${12000 + index * 1500}; easing: easeInOutSine; loop: true; to: #a0b6d0`);
-            pillarGroup.appendChild(pillarCore);
-
-            const baseEl = document.createElement('a-cylinder');
-            const baseRadius = (Math.max(pillar.width, pillar.depth) * 0.65).toFixed(2);
-            baseEl.setAttribute('radius', baseRadius);
-            baseEl.setAttribute('height', '0.6');
-            baseEl.setAttribute('color', pillar.baseColor || '#607593');
-            baseEl.setAttribute('material', 'shader: flat');
-            baseEl.setAttribute('position', '0 0.3 0');
-            pillarGroup.appendChild(baseEl);
-
-            const accentHeights = pillar.accentRatios || [0.18, 0.42, 0.68, 0.92];
-            accentHeights.forEach((ratio) => {
-                const accent = document.createElement('a-cylinder');
-                const accentRadius = (Math.max(pillar.width, pillar.depth) * (0.42 + ratio * 0.12)).toFixed(2);
-                accent.setAttribute('radius', accentRadius);
-                accent.setAttribute('height', '0.2');
-                accent.setAttribute('color', pillar.accentColor || '#9fb6cf');
-                accent.setAttribute('material', 'shader: flat; opacity: 0.82');
-                accent.setAttribute('position', `0 ${pillar.height * ratio} 0`);
-                pillarGroup.appendChild(accent);
-            });
-
-            const halfWidth = pillar.width / 2;
-            const halfDepth = pillar.depth / 2;
-            const ribWidth = Math.max(0.22, pillar.width * 0.22);
-            const ribDepth = Math.max(0.22, pillar.depth * 0.22);
-            const ribHeight = pillar.height * 0.7;
-            const ribYOffset = pillar.height * 0.25 + ribHeight / 2;
-            const surfaceInset = 0.04;
-            const ribOffsets = [
-                { axis: 'x', direction: 1, width: ribWidth, depth: ribDepth * 0.6 },
-                { axis: 'x', direction: -1, width: ribWidth, depth: ribDepth * 0.6 },
-                { axis: 'z', direction: 1, width: ribDepth * 0.6, depth: ribDepth },
-                { axis: 'z', direction: -1, width: ribDepth * 0.6, depth: ribDepth }
-            ];
-
-            ribOffsets.forEach((offset) => {
-                const rib = document.createElement('a-box');
-                const ribWidthValue = offset.width;
-                const ribDepthValue = offset.depth;
-                rib.setAttribute('width', ribWidthValue.toFixed(2));
-                rib.setAttribute('depth', ribDepthValue.toFixed(2));
-                rib.setAttribute('height', ribHeight.toFixed(2));
-                rib.setAttribute('color', '#4e6178');
-                rib.setAttribute('material', 'shader: flat; opacity: 0.7; side: double');
-
-                if (offset.axis === 'x') {
-                    const available = Math.max(0, halfWidth - ribWidthValue / 2);
-                    const inset = Math.min(available, surfaceInset);
-                    const positionX = offset.direction * (available - inset);
-                    rib.setAttribute('position', `${positionX.toFixed(2)} ${ribYOffset.toFixed(2)} 0`);
-                } else {
-                    const available = Math.max(0, halfDepth - ribDepthValue / 2);
-                    const inset = Math.min(available, surfaceInset);
-                    const positionZ = offset.direction * (available - inset);
-                    rib.setAttribute('position', `0 ${ribYOffset.toFixed(2)} ${positionZ.toFixed(2)}`);
-                }
-                pillarGroup.appendChild(rib);
-            });
-
-            const capRing = document.createElement('a-cylinder');
-            const capRadius = (Math.max(pillar.width, pillar.depth) * 0.6).toFixed(2);
-            capRing.setAttribute('radius', capRadius);
-            capRing.setAttribute('height', '0.25');
-            capRing.setAttribute('color', pillar.accentColor || '#d4e0f2');
-            capRing.setAttribute('material', 'shader: flat; opacity: 0.9');
-            capRing.setAttribute('position', `0 ${pillar.height - 0.25} 0`);
-            pillarGroup.appendChild(capRing);
-
-            const capGlow = document.createElement('a-sphere');
-            const glowRadius = (Math.max(pillar.width, pillar.depth) * 0.35).toFixed(2);
-            capGlow.setAttribute('radius', glowRadius);
-            capGlow.setAttribute('color', pillar.glowColor || '#e4ebf6');
-            capGlow.setAttribute('material', 'shader: flat; opacity: 0.95');
-            capGlow.setAttribute('position', `0 ${pillar.height + 0.5} 0`);
-            capGlow.setAttribute('animation__pulse', 'property: scale; dir: alternate; dur: 6000; easing: easeInOutSine; loop: true; to: 1.05 1.15 1.05');
-            pillarGroup.appendChild(capGlow);
-
-            this.decorRoot.appendChild(pillarGroup);
-        });
-
-        // Plates-formes flottantes simples
-        const floatingPlatforms = [
-            { x: 6, y: -1, z: -10, scale: '2 0.1 2', hover: 0.4, phase: 0 },
-            { x: -8, y: -0.5, z: -14, scale: '1.5 0.1 1.5', hover: 0.25, phase: 2000 },
-            { x: 10, y: 1, z: 12, scale: '1.8 0.1 1.8', hover: 0.35, phase: 4000 },
-            { x: -4, y: 1.5, z: 18, scale: '1.2 0.08 2.4', hover: 0.2, phase: 1500 }
-        ];
-
-        floatingPlatforms.forEach((platform) => {
-            const platformEl = document.createElement('a-box');
-            platformEl.setAttribute('color', '#c6d6e5');
-            platformEl.setAttribute('scale', platform.scale);
-            platformEl.setAttribute('position', `${platform.x} ${platform.y} ${platform.z}`);
-            platformEl.setAttribute('material', 'shader: flat');
-            platformEl.setAttribute('animation__hover', `property: position; dir: alternate; dur: ${10000 + platform.phase}; easing: easeInOutSine; loop: true; to: ${platform.x} ${platform.y + platform.hover} ${platform.z}; delay: ${platform.phase}`);
-            this.decorRoot.appendChild(platformEl);
-        });
-
-        // Nuages stylisés très simples et animés lentement
-        const cloudData = [
-            { x: 8, y: 9, z: -12, scale: '3.2 1.4 1.4', delay: 0, drift: 3 },
-            { x: -10, y: 10, z: 14, scale: '2.7 1.2 1.2', delay: 2000, drift: 2 },
-            { x: -4, y: 8, z: -16, scale: '3.6 1.5 1.5', delay: 4000, drift: 4 },
-            { x: 14, y: 11, z: 22, scale: '4.2 1.8 1.8', delay: 6000, drift: 5 }
-        ];
-
-        cloudData.forEach((cloud) => {
-            const cloudEl = document.createElement('a-sphere');
-            cloudEl.setAttribute('color', '#ffffff');
-            cloudEl.setAttribute('position', `${cloud.x} ${cloud.y} ${cloud.z}`);
-            cloudEl.setAttribute('scale', cloud.scale);
-            cloudEl.setAttribute('opacity', '0.85');
-            cloudEl.setAttribute('material', 'shader: flat');
-            cloudEl.setAttribute('animation__float', `property: position; dir: alternate; dur: 12000; easing: easeInOutSine; loop: true; to: ${cloud.x} ${cloud.y + 0.8} ${cloud.z}; delay: ${cloud.delay}`);
-            cloudEl.setAttribute('animation__drift', `property: position; dir: alternate; dur: ${18000 + cloud.delay}; easing: easeInOutSine; loop: true; to: ${cloud.x + cloud.drift} ${cloud.y} ${cloud.z}; delay: ${cloud.delay / 2}`);
-            this.decorRoot.appendChild(cloudEl);
-        });
-
-        const upperClouds = [
-            { x: -16, y: 15, z: -28, scale: '4.5 1.6 1.6', delay: 1000, drift: 3.5 },
-            { x: 18, y: 16, z: 30, scale: '5.2 1.9 1.9', delay: 2500, drift: 4.5 },
-            { x: 4, y: 14, z: 26, scale: '3.8 1.5 1.5', delay: 4200, drift: 3 }
-        ];
-
-        upperClouds.forEach((cloud) => {
-            const highCloud = document.createElement('a-sphere');
-            highCloud.setAttribute('color', '#ffffff');
-            highCloud.setAttribute('position', `${cloud.x} ${cloud.y} ${cloud.z}`);
-            highCloud.setAttribute('scale', cloud.scale);
-            highCloud.setAttribute('opacity', '0.75');
-            highCloud.setAttribute('material', 'shader: flat');
-            highCloud.setAttribute('animation__float', `property: position; dir: alternate; dur: 16000; easing: easeInOutSine; loop: true; to: ${cloud.x} ${cloud.y + 1.2} ${cloud.z}; delay: ${cloud.delay}`);
-            highCloud.setAttribute('animation__drift', `property: position; dir: alternate; dur: ${22000 + cloud.delay}; easing: easeInOutSine; loop: true; to: ${cloud.x - cloud.drift} ${cloud.y} ${cloud.z + cloud.drift}; delay: ${cloud.delay / 2}`);
-            this.decorRoot.appendChild(highCloud);
-        });
-
-        // Bandes de nuages lointains pour suggérer un vent doux
-        const farCloudBands = [
-            { y: 4, from: -25, to: 25, z: -35, width: 40, delay: 0 },
-            { y: 9, from: 22, to: -18, z: 38, width: 36, delay: 4000 }
-        ];
-
-        farCloudBands.forEach((band) => {
-            const bandEl = document.createElement('a-plane');
-            bandEl.setAttribute('width', `${band.width}`);
-            bandEl.setAttribute('height', '6');
-            bandEl.setAttribute('material', 'shader: flat; color: #ffffff; opacity: 0.18; side: double');
-            bandEl.setAttribute('rotation', '0 0 0');
-            bandEl.setAttribute('position', `0 ${band.y} ${band.z}`);
-            bandEl.setAttribute('animation__wind', `property: position; dir: alternate; dur: 24000; easing: easeInOutSine; loop: true; to: ${band.to} ${band.y} ${band.z}; from: ${band.from} ${band.y} ${band.z}; delay: ${band.delay}`);
-            this.decorRoot.appendChild(bandEl);
-        });
-
-        // Flux de vent lumineux pour dynamiser l'arrière-plan
-        const windTrails = [
-            { position: '-12 2 -22', rotation: '0 10 0', length: 14 },
-            { position: '16 3 28', rotation: '0 -20 0', length: 18 }
-        ];
-
-        windTrails.forEach((trail) => {
-            const trailEl = document.createElement('a-plane');
-            trailEl.setAttribute('width', `${trail.length}`);
-            trailEl.setAttribute('height', '1.6');
-            trailEl.setAttribute('material', 'shader: flat; color: #b9ddff; opacity: 0.12; side: double');
-            trailEl.setAttribute('position', trail.position);
-            trailEl.setAttribute('rotation', trail.rotation);
-            trailEl.setAttribute('animation__pulse', 'property: material.opacity; dir: alternate; dur: 3500; easing: easeInOutSine; loop: true; to: 0.22');
-            this.decorRoot.appendChild(trailEl);
-        });
-
-        // Ballons d'altitude lointains pour renforcer la perception de verticalité
-        const tetheredBalloons = [
-            { x: 20, y: 15, z: -30, color: '#ffcf66', bob: 1.6, delay: 0 },
-            { x: -24, y: 13, z: 34, color: '#8ed6ff', bob: 1.1, delay: 2200 }
-        ];
-
-        tetheredBalloons.forEach((balloon) => {
-            const balloonEl = document.createElement('a-sphere');
-            balloonEl.setAttribute('radius', '1.5');
-            balloonEl.setAttribute('color', balloon.color);
-            balloonEl.setAttribute('position', `${balloon.x} ${balloon.y} ${balloon.z}`);
-            balloonEl.setAttribute('material', 'shader: flat; opacity: 0.95');
-            balloonEl.setAttribute('animation__bob', `property: position; dir: alternate; dur: ${9000 + balloon.delay}; easing: easeInOutSine; loop: true; to: ${balloon.x} ${balloon.y + balloon.bob} ${balloon.z}; delay: ${balloon.delay}`);
-
-            const tetherEl = document.createElement('a-cylinder');
-            tetherEl.setAttribute('radius', '0.02');
-            tetherEl.setAttribute('height', `${balloon.y + 3}`);
-            tetherEl.setAttribute('color', '#f9f1d0');
-            tetherEl.setAttribute('position', `${balloon.x} ${(balloon.y - 3) / 2} ${balloon.z}`);
-            tetherEl.setAttribute('material', 'shader: flat; opacity: 0.6');
-
-            this.decorRoot.appendChild(balloonEl);
-            this.decorRoot.appendChild(tetherEl);
-        });
-
-        const stylizedTrees = [
-            { x: 26, z: -14, trunkHeight: 3.2, canopyScale: '2.6 2.8 2.6', sway: 0.18, canopyColor: '#7ec87c', highlightColor: '#a8e0a2' },
-            { x: -28, z: -10, trunkHeight: 4, canopyScale: '3 3.4 3', sway: 0.24, canopyColor: '#6fc47a', highlightColor: '#97de9f' },
-            { x: 24, z: 18, trunkHeight: 3.6, canopyScale: '2.4 2.6 2.4', sway: 0.16, canopyColor: '#8cd290', highlightColor: '#b6e9b8' },
-            { x: -22, z: 22, trunkHeight: 3.8, canopyScale: '2.8 3 2.8', sway: 0.2, canopyColor: '#75c080', highlightColor: '#a6e0ae' },
-            { x: 30, z: 28, trunkHeight: 4.4, canopyScale: '2.2 2.4 2.2', sway: 0.14, canopyColor: '#82c88a', highlightColor: '#b2e3b7' },
-            { x: -34, z: 18, trunkHeight: 4.8, canopyScale: '2.6 2.9 2.6', sway: 0.22, canopyColor: '#6abd78', highlightColor: '#9ddc9f' },
-            { x: 20, z: -28, trunkHeight: 3.4, canopyScale: '2.3 2.5 2.3', sway: 0.17, canopyColor: '#78c684', highlightColor: '#a7e0b0' },
-            { x: -26, z: -24, trunkHeight: 4.2, canopyScale: '2.9 3.1 2.9', sway: 0.19, canopyColor: '#89ce92', highlightColor: '#bce8c1' }
-        ];
-
-        stylizedTrees.forEach((tree, index) => {
-            const treeGroup = document.createElement('a-entity');
-            treeGroup.setAttribute('position', `${tree.x} -1.2 ${tree.z - 2}`);
-
-            const trunk = document.createElement('a-cylinder');
-            trunk.setAttribute('radius', '0.28');
-            trunk.setAttribute('height', tree.trunkHeight);
-            trunk.setAttribute('position', `0 ${tree.trunkHeight / 2} 0`);
-            trunk.setAttribute('color', '#6b4f2c');
-            trunk.setAttribute('material', 'shader: flat');
-            treeGroup.appendChild(trunk);
-
-            const canopy = document.createElement('a-sphere');
-            canopy.setAttribute('position', `0 ${tree.trunkHeight + 0.8} 0`);
-            canopy.setAttribute('scale', tree.canopyScale);
-            canopy.setAttribute('color', tree.canopyColor);
-            canopy.setAttribute('material', 'shader: flat; roughness: 0.7');
-            canopy.setAttribute('animation__sway', `property: rotation; dir: alternate; dur: ${6000 + index * 1200}; easing: easeInOutSine; loop: true; to: ${tree.sway * 60} ${tree.sway * 80} ${tree.sway * -40}`);
-            treeGroup.appendChild(canopy);
-
-            const canopyHighlight = document.createElement('a-sphere');
-            canopyHighlight.setAttribute('position', `0 ${tree.trunkHeight + 0.8} 0`);
-            canopyHighlight.setAttribute('scale', '1.2 0.8 1.2');
-            canopyHighlight.setAttribute('color', tree.highlightColor);
-            canopyHighlight.setAttribute('material', 'shader: flat; opacity: 0.4');
-            treeGroup.appendChild(canopyHighlight);
-
-            this.decorRoot.appendChild(treeGroup);
-        });
-
-        sceneEl.appendChild(this.decorRoot);
-        sceneEl.setAttribute('fog', 'type: exponential; color: #d6ecff; density: 0.018');
+        this.currentDensity = newDensity;
+        if (this.sceneEl) {
+            this._rebuild();
+        }
     },
 
-    /**
-     * Supprime le décor de la scène et restaure la configuration précédente.
-     */
+    _rebuild() {
+        if (!this.sceneEl) {
+            return;
+        }
+
+        if (this.decorRoot && this.decorRoot.parentNode) {
+            this.decorRoot.parentNode.removeChild(this.decorRoot);
+        }
+
+        this.decorRoot = createEntity('a-entity', { id: 'heights-decor-root' });
+
+        addBaseStructures(this.decorRoot);
+        addCloseTowerRing(this.decorRoot, this.currentDensity);
+        addHoveringWalkways(this.decorRoot, this.currentDensity);
+        addArches(this.decorRoot, this.currentDensity);
+        addPillarClusters(this.decorRoot, this.currentDensity);
+        addFloatingPlatforms(this.decorRoot, this.currentDensity);
+        addClouds(this.decorRoot, this.currentDensity);
+        addWindTrails(this.decorRoot, this.currentDensity);
+        addBalloons(this.decorRoot, this.currentDensity);
+        addTrees(this.decorRoot, this.currentDensity);
+        addMountainSilhouettes(this.decorRoot, this.currentDensity);
+        addSkyLanterns(this.decorRoot, this.currentDensity);
+
+        this.sceneEl.appendChild(this.decorRoot);
+        this.sceneEl.setAttribute('fog', 'type: exponential; color: #d6ecff; density: 0.018');
+    },
+
     cleanup() {
         if (this.decorRoot && this.decorRoot.parentNode) {
             this.decorRoot.parentNode.removeChild(this.decorRoot);
@@ -351,5 +668,6 @@ export const heightsDecorModule = {
         this.decorRoot = null;
         this.sceneEl = null;
         this.originalFog = null;
+        this.currentDensity = 'immersive';
     }
 };

--- a/visuals/heights.js
+++ b/visuals/heights.js
@@ -7,6 +7,14 @@ import { heightsDecorModule } from './decor_heights.js';
 // --- Private State ---
 let sceneEl, rigEl;
 let platformEl;
+const platformElements = {
+    base: null,
+    top: null,
+    marker: null,
+    stripes: [],
+    posts: [],
+    rails: []
+};
 let skyEl;
 let animationFrameId;
 let actualSpeed = 0;
@@ -18,6 +26,7 @@ let lastReportedAltitude = null;
 let unsubscribeFromState = null;
 let platformScale = 1;
 let decorDensityLevel = 'immersive';
+let currentPaletteKey = 'default';
 
 const BASE_ALTITUDE = 1;
 const MIN_ALTITUDE = BASE_ALTITUDE;
@@ -33,37 +42,88 @@ function _reportAltitude(force = false) {
 }
 
 // --- Core Logic ---
+function _resetPlatformElements() {
+    platformElements.base = null;
+    platformElements.top = null;
+    platformElements.marker = null;
+    platformElements.stripes = [];
+    platformElements.posts = [];
+    platformElements.rails = [];
+}
+
+function _applyPlatformTheme() {
+    if (!platformEl) {
+        return;
+    }
+
+    const theme = heightsDecorModule.getCurrentTheme();
+
+    if (platformElements.base) {
+        platformElements.base.setAttribute('color', theme.platformBaseColor);
+    }
+
+    if (platformElements.top) {
+        platformElements.top.setAttribute('color', theme.platformTopColor);
+    }
+
+    if (platformElements.marker) {
+        platformElements.marker.setAttribute('color', theme.platformMarkerColor);
+    }
+
+    platformElements.stripes.forEach((stripe) => {
+        stripe.setAttribute('color', theme.platformStripeColor);
+    });
+
+    platformElements.posts.forEach((post) => {
+        post.setAttribute('color', theme.platformPostColor);
+    });
+
+    platformElements.rails.forEach((rail) => {
+        rail.setAttribute('color', theme.platformRailColor);
+    });
+
+    if (skyEl) {
+        skyEl.setAttribute('color', theme.skyColor);
+    }
+}
+
 function _createElements() {
     // Conteneur principal de la plateforme et de ses éléments décoratifs
     platformEl = document.createElement('a-entity');
     platformEl.setAttribute('id', 'height-platform');
     platformEl.setAttribute('position', `0 ${BASE_ALTITUDE} -2`);
 
+    _resetPlatformElements();
+    const theme = heightsDecorModule.getCurrentTheme();
+
     // Socle principal (base large)
     const baseEl = document.createElement('a-cylinder');
     baseEl.setAttribute('radius', '2.2');
     baseEl.setAttribute('height', '0.3');
-    baseEl.setAttribute('color', '#2c3e50');
+    baseEl.setAttribute('color', theme.platformBaseColor);
     baseEl.setAttribute('position', '0 -0.15 0');
     baseEl.setAttribute('segments-radial', '24');
     platformEl.appendChild(baseEl);
+    platformElements.base = baseEl;
 
     // Plateau supérieur avec une teinte plus claire
     const topSurfaceEl = document.createElement('a-cylinder');
     topSurfaceEl.setAttribute('radius', '2');
     topSurfaceEl.setAttribute('height', '0.08');
-    topSurfaceEl.setAttribute('color', '#4A90E2');
+    topSurfaceEl.setAttribute('color', theme.platformTopColor);
     topSurfaceEl.setAttribute('position', '0 0 0');
     topSurfaceEl.setAttribute('material', 'shader: flat; metalness: 0.1; roughness: 0.4');
     platformEl.appendChild(topSurfaceEl);
+    platformElements.top = topSurfaceEl;
 
     // Marqueur central pour aider à se positionner
     const centerMarker = document.createElement('a-cylinder');
     centerMarker.setAttribute('radius', '0.35');
     centerMarker.setAttribute('height', '0.01');
-    centerMarker.setAttribute('color', '#f8f9fa');
+    centerMarker.setAttribute('color', theme.platformMarkerColor);
     centerMarker.setAttribute('position', '0 0.045 0');
     platformEl.appendChild(centerMarker);
+    platformElements.marker = centerMarker;
 
     // Bandes directionnelles (N, S, E, O)
     const stripeData = [
@@ -78,11 +138,12 @@ function _createElements() {
         stripeEl.setAttribute('depth', '0.2');
         stripeEl.setAttribute('height', '0.01');
         stripeEl.setAttribute('width', '0.5');
-        stripeEl.setAttribute('color', '#d9e8ff');
+        stripeEl.setAttribute('color', theme.platformStripeColor);
         stripeEl.setAttribute('opacity', '0.9');
         stripeEl.setAttribute('position', `${stripe.x} 0.045 ${stripe.z}`);
         stripeEl.setAttribute('rotation', stripe.rotation);
         platformEl.appendChild(stripeEl);
+        platformElements.stripes.push(stripeEl);
     });
 
     // Potelets de sécurité aux quatre coins
@@ -97,9 +158,10 @@ function _createElements() {
         const postEl = document.createElement('a-cylinder');
         postEl.setAttribute('radius', '0.05');
         postEl.setAttribute('height', '1.1');
-        postEl.setAttribute('color', '#cfd9e8');
+        postEl.setAttribute('color', theme.platformPostColor);
         postEl.setAttribute('position', `${pos.x} 0.55 ${pos.z}`);
         platformEl.appendChild(postEl);
+        platformElements.posts.push(postEl);
     });
 
     // Rubans de sécurité semi-transparents
@@ -113,11 +175,12 @@ function _createElements() {
         railEl.setAttribute('width', '3.2');
         railEl.setAttribute('height', '0.06');
         railEl.setAttribute('depth', '0.02');
-        railEl.setAttribute('color', '#b3c4e0');
+        railEl.setAttribute('color', theme.platformRailColor);
         railEl.setAttribute('opacity', '0.55');
         railEl.setAttribute('position', rail.position);
         railEl.setAttribute('rotation', rail.rotation);
         platformEl.appendChild(railEl);
+        platformElements.rails.push(railEl);
     });
 
     const verticalRails = [
@@ -130,15 +193,17 @@ function _createElements() {
         railEl.setAttribute('width', '3.2');
         railEl.setAttribute('height', '0.06');
         railEl.setAttribute('depth', '0.02');
-        railEl.setAttribute('color', '#b3c4e0');
+        railEl.setAttribute('color', theme.platformRailColor);
         railEl.setAttribute('opacity', '0.55');
         railEl.setAttribute('position', rail.position);
         railEl.setAttribute('rotation', rail.rotation);
         platformEl.appendChild(railEl);
+        platformElements.rails.push(railEl);
     });
 
     sceneEl.appendChild(platformEl);
     _applyPlatformScale();
+    _applyPlatformTheme();
 }
 
 function _applyPlatformScale() {
@@ -202,14 +267,12 @@ export const heightsModule = {
         const { visual } = stateManager.getState();
         platformScale = visual.platformScale ?? platformScale;
         decorDensityLevel = visual.heightsDecorDensity ?? decorDensityLevel;
+        currentPaletteKey = visual.palette ?? currentPaletteKey;
 
         // Créer le décor via son module dédié
-        heightsDecorModule.create(sceneEl, decorDensityLevel);
+        heightsDecorModule.create(sceneEl, decorDensityLevel, currentPaletteKey);
 
         skyEl = sceneEl.querySelector('#sky');
-        if (skyEl) {
-            skyEl.setAttribute('color', '#8dc6ff');
-        }
 
         // Réinitialiser la position et la rotation du rig pour cet exercice.
         if (rigEl) {
@@ -222,6 +285,7 @@ export const heightsModule = {
             platformEl.object3D.position.y = BASE_ALTITUDE;
             _applyPlatformScale();
         }
+        _applyPlatformTheme();
         lastFrameTime = performance.now();
         currentAltitude = rigEl ? rigEl.object3D.position.y : BASE_ALTITUDE;
         lastReportedAltitude = null;
@@ -248,6 +312,11 @@ export const heightsModule = {
         if (desiredDensity !== decorDensityLevel) {
             this.setDecorDensity(desiredDensity);
         }
+
+        const desiredPalette = newState.visual.palette ?? currentPaletteKey;
+        if (desiredPalette !== currentPaletteKey) {
+            this.setPalette(desiredPalette);
+        }
     },
 
     cleanup() {
@@ -265,11 +334,13 @@ export const heightsModule = {
             platformEl.parentNode.removeChild(platformEl);
         }
         platformEl = null;
+        _resetPlatformElements();
         actualSpeed = 0;
         targetSpeed = 0;
         currentAltitude = 0;
         lastReportedAltitude = null;
         decorDensityLevel = 'immersive';
+        currentPaletteKey = 'default';
         // Réinitialiser la position du rig
         if(rigEl) {
             rigEl.object3D.position.y = 0;
@@ -319,10 +390,17 @@ export const heightsModule = {
 
         decorDensityLevel = densityLevel;
         heightsDecorModule.updateDensity(densityLevel);
+        _applyPlatformTheme();
     },
-    
+
+    setPalette(paletteKey) {
+        const normalizedKey = paletteKey === 'auto' ? 'default' : (paletteKey || 'default');
+        currentPaletteKey = normalizedKey;
+        heightsDecorModule.updatePalette(normalizedKey);
+        _applyPlatformTheme();
+    },
+
     // --- Fonctions non utilisées mais requises ---
     setDensity() {},
-    setPalette() {},
     getActualSpeed() { return { v: actualSpeed }; }
 };

--- a/visuals/heights.js
+++ b/visuals/heights.js
@@ -17,6 +17,7 @@ let currentAltitude = 0;
 let lastReportedAltitude = null;
 let unsubscribeFromState = null;
 let platformScale = 1;
+let decorDensityLevel = 'immersive';
 
 const BASE_ALTITUDE = 1;
 const MIN_ALTITUDE = BASE_ALTITUDE;
@@ -198,11 +199,12 @@ export const heightsModule = {
         }
         unsubscribeFromState = stateManager.subscribe(this.onStateChange.bind(this));
 
-        // Créer le décor via son module dédié
-        heightsDecorModule.create(sceneEl);
-
         const { visual } = stateManager.getState();
         platformScale = visual.platformScale ?? platformScale;
+        decorDensityLevel = visual.heightsDecorDensity ?? decorDensityLevel;
+
+        // Créer le décor via son module dédié
+        heightsDecorModule.create(sceneEl, decorDensityLevel);
 
         skyEl = sceneEl.querySelector('#sky');
         if (skyEl) {
@@ -241,6 +243,11 @@ export const heightsModule = {
         if (Math.abs(desiredScale - platformScale) > 0.0001) {
             this.setPlatformScale(desiredScale);
         }
+
+        const desiredDensity = newState.visual.heightsDecorDensity ?? decorDensityLevel;
+        if (desiredDensity !== decorDensityLevel) {
+            this.setDecorDensity(desiredDensity);
+        }
     },
 
     cleanup() {
@@ -262,6 +269,7 @@ export const heightsModule = {
         targetSpeed = 0;
         currentAltitude = 0;
         lastReportedAltitude = null;
+        decorDensityLevel = 'immersive';
         // Réinitialiser la position du rig
         if(rigEl) {
             rigEl.object3D.position.y = 0;
@@ -295,13 +303,22 @@ export const heightsModule = {
             return;
         }
 
-        const clampedScale = Math.max(0.5, Math.min(1.0, scale));
+        const clampedScale = Math.max(0.25, Math.min(1.0, scale));
         if (Math.abs(clampedScale - platformScale) < 0.0001) {
             return;
         }
 
         platformScale = clampedScale;
         _applyPlatformScale();
+    },
+
+    setDecorDensity(densityLevel) {
+        if (typeof densityLevel !== 'string') {
+            return;
+        }
+
+        decorDensityLevel = densityLevel;
+        heightsDecorModule.updateDensity(densityLevel);
     },
     
     // --- Fonctions non utilisées mais requises ---


### PR DESCRIPTION
## Résumé
- proposer cinq tailles de plateforme dont une nouvelle option à 25 % pour l’exercice Hauteurs
- ajouter un sélecteur de richesse du décor et synchroniser l’état partagé avec le module
- reconstruire le décor des hauteurs avec davantage d’éléments proches, arches, montagnes et options de densité

## Tests
- aucun test automatisé disponible

------
https://chatgpt.com/codex/tasks/task_e_68f684cba530832387fa0d1b02e19880