### PR TITLE
Adjust Quest defaults and controller mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.90 (2025-10-25)
+
+* Correction de l'orientation des halos optocinétiques en VR en récupérant explicitement la caméra WebXR active (sous-caméra Quest incluse).
+* Nouveau mapping des manettes : bouton B accélère la vitesse principale, bouton A la réduit et le clic joystick droit revient à la fonction Recentrer.
+* Affichage automatique du pavé de raccourcis fléchés sur Quest pour préparer les réglages sans manette active.
+* Mise à jour des références de version de l'application et du service worker en 0.90.
+
 ## v0.89 (2025-10-24)
 
 * Détection automatique de l'Oculus Quest avec affichage du statut dans la console et vitesse optocinétique initialisée à 5°/s pour faciliter les tests sur casque autonome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.89 (2025-10-24)
+
+* Détection automatique de l'Oculus Quest avec affichage du statut dans la console et vitesse optocinétique initialisée à 5°/s pour faciliter les tests sur casque autonome.
+* Remappage des contrôleurs : le clic du joystick droit passe à la stimulation suivante, les boutons B/X/Y et le joystick gauche restent disponibles avec un seuil réduit pour déclencher plus facilement les déplacements.
+* Mise en double face des halos optocinétiques afin de vérifier l'affichage à 360° pendant l'investigation des soucis de billboard sur Quest.
+* Mise à jour des références de version de l'application et du service worker en 0.89.
+
 ## v0.88 (2025-10-23)
 
 * Horizon des hauteurs élargi avec un disque de sol plus vaste et des terrasses étagées plus larges pour accentuer la sensation de profondeur.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.91 (2025-10-26)
+
+* Remplacement des `requestAnimationFrame` locaux par un composant A-Frame dédié afin que l'optocinétique, le flux optique et les hauteurs continuent d'animer en session WebXR (Quest inclus).
+* Harmonisation des manettes Quest : suppression du rayon laser forcé, mêmes actions sur les deux mains (A/B/X/Y, joystick, clic) et sélection élargie des entités contrôleur.
+* Mise à jour des références de version de l'application et du service worker en 0.91.
+
 ## v0.90 (2025-10-25)
 
 * Correction de l'orientation des halos optocinétiques en VR en récupérant explicitement la caméra WebXR active (sous-caméra Quest incluse).

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.89</title>
+    <title>OW v0.90</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.89">
+    <link rel="stylesheet" href="styles.css?v=0.90">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.89</div>
+        <div id="version-display">v0.90</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -247,7 +247,7 @@
         </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.89"></script>
+    <script type="module" src="main.js?v=0.90"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.88</title>
+    <title>OW v0.89</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.88">
+    <link rel="stylesheet" href="styles.css?v=0.89">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.88</div>
+        <div id="version-display">v0.89</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -247,7 +247,7 @@
         </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.88"></script>
+    <script type="module" src="main.js?v=0.89"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>OW v0.90</title>
+    <title>OW v0.91</title>
     <meta name="description" content="Application de rééducation vestibulaire en réalité virtuelle.">
     <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
-    <link rel="stylesheet" href="styles.css?v=0.90">
+    <link rel="stylesheet" href="styles.css?v=0.91">
         <link rel="manifest" href="manifest.json">
     </head>
     <body>
 
-        <div id="version-display">v0.90</div>
+        <div id="version-display">v0.91</div>
 
     <div class="ui-panels-container has-mobile-tabs">
         <div class="mobile-tabbar" role="tablist" aria-label="Panneaux de configuration">
@@ -247,7 +247,7 @@
         </a-entity>
     </a-scene>
 
-    <script type="module" src="main.js?v=0.90"></script>
+    <script type="module" src="main.js?v=0.91"></script>
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {

--- a/main.js
+++ b/main.js
@@ -103,14 +103,36 @@ document.addEventListener('DOMContentLoaded', () => {
     const translationSpeedIncrement = 0.5;
     const heightSpeedIncrement = 0.2;
 
+    const adjustPrimarySpeed = (currentState, step) => {
+        const moduleName = visualSelect.value;
+        const newSpeeds = { ...currentState.visual.speeds };
+        let hasUpdated = false;
+
+        if (moduleName === 'optokinetic') {
+            newSpeeds.h += speedIncrement * step;
+            hasUpdated = true;
+        } else if (moduleName === 'opticalFlow') {
+            newSpeeds.t += translationSpeedIncrement * step;
+            hasUpdated = true;
+        } else if (moduleName === 'heights') {
+            const nextValue = newSpeeds.y + heightSpeedIncrement * step;
+            newSpeeds.y = Math.max(-5, Math.min(5, nextValue));
+            hasUpdated = true;
+        }
+
+        if (hasUpdated) {
+            stateManager.setState({ visual: { ...currentState.visual, speeds: newSpeeds } });
+        }
+
+        return hasUpdated;
+    };
+
     const VisualModules = {
         none: null,
         optokinetic: optokineticModule,
         opticalFlow: opticalFlowModule,
         heights: heightsModule
     };
-
-    const visualModuleCycle = ['optokinetic', 'opticalFlow', 'heights'];
 
     // --- Core Functions ---
 
@@ -191,19 +213,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         stateManager.setState({ visual: baseVisualState });
     }
-
-    const activateNextVisualModule = () => {
-        const currentValue = visualSelect.value;
-        const currentIndex = visualModuleCycle.indexOf(currentValue);
-        const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % visualModuleCycle.length;
-        const nextModule = visualModuleCycle[nextIndex];
-
-        if (nextModule !== currentValue) {
-            visualSelect.value = nextModule;
-        }
-
-        setActiveVisualModule(nextModule);
-    };
 
     function getHorizontalForwardQuaternion() {
         const cameraQuaternion = new THREE.Quaternion();
@@ -672,6 +681,16 @@ document.addEventListener('DOMContentLoaded', () => {
         let newSpeeds = { ...currentState.visual.speeds };
         let speedUpdated = false;
 
+        if (key === 'quest-speed-increase') {
+            if (adjustPrimarySpeed(currentState, 1)) {
+                return;
+            }
+        } else if (key === 'quest-speed-decrease') {
+            if (adjustPrimarySpeed(currentState, -1)) {
+                return;
+            }
+        }
+
         if (activeVisualModule) {
             if (moduleName === 'optokinetic') {
                 switch (key) {
@@ -757,6 +776,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const controllerState = { horizontal: null, vertical: null };
         vrControllerStates.set(controllerEl, controllerState);
 
+        controllerEl.setAttribute('raycaster', {
+            showLine: true,
+            far: 12
+        });
+
         controllerEl.addEventListener('thumbstickmoved', (event) => {
             const { x = 0, y = 0 } = event.detail || {};
             processControllerAxes(controllerState, x, y);
@@ -768,19 +792,18 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         const triggerRecenter = () => handleControlInput('r');
-        const triggerStop = () => handleControlInput(' ');
+        const triggerPrimaryIncrease = () => handleControlInput('quest-speed-increase');
+        const triggerPrimaryDecrease = () => handleControlInput('quest-speed-decrease');
         const triggerVerticalIncrease = () => handleControlInput('arrowup');
         const triggerVerticalDecrease = () => handleControlInput('arrowdown');
 
-        controllerEl.addEventListener('abuttondown', triggerRecenter);
-        controllerEl.addEventListener('bbuttondown', triggerStop);
+        controllerEl.addEventListener('abuttondown', triggerPrimaryDecrease);
+        controllerEl.addEventListener('bbuttondown', triggerPrimaryIncrease);
         controllerEl.addEventListener('ybuttondown', triggerVerticalIncrease);
         controllerEl.addEventListener('xbuttondown', triggerVerticalDecrease);
 
         if (controllerEl.id === 'right-controller') {
-            controllerEl.addEventListener('thumbstickdown', () => {
-                activateNextVisualModule();
-            });
+            controllerEl.addEventListener('thumbstickdown', triggerRecenter);
         }
     };
 

--- a/main.js
+++ b/main.js
@@ -46,6 +46,20 @@ AFRAME.registerComponent('exercise-ticker', {
     }
 });
 
+AFRAME.registerComponent('visuals-ticker', {
+    init: function () {
+        this.activeVisualModule = null;
+    },
+    tick: function (time, timeDelta) {
+        if (this.activeVisualModule && typeof this.activeVisualModule.tick === 'function') {
+            this.activeVisualModule.tick(time, timeDelta);
+        }
+    },
+    setActiveModule: function (module) {
+        this.activeVisualModule = module || null;
+    }
+});
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- DOM Elements ---
     const sceneEl = document.querySelector('a-scene');
@@ -89,6 +103,8 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     const mobileMediaQuery = window.matchMedia('(max-width: 768px)');
     let activeMobileTabId = 'visual-panel';
+
+    sceneEl.setAttribute('visuals-ticker', '');
 
     const isQuestPlatform = detectQuestHeadset();
     if (isQuestPlatform) {
@@ -168,7 +184,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    const updateVisualTickerModule = (moduleInstance) => {
+        const tickerComponent = sceneEl.components['visuals-ticker'];
+        if (tickerComponent && typeof tickerComponent.setActiveModule === 'function') {
+            tickerComponent.setActiveModule(moduleInstance);
+        }
+    };
+
     function setActiveVisualModule(moduleName) {
+        updateVisualTickerModule(null);
         if (activeVisualModule && typeof activeVisualModule.cleanup === 'function') {
             activeVisualModule.cleanup();
         }
@@ -212,6 +236,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         stateManager.setState({ visual: baseVisualState });
+        updateVisualTickerModule(activeVisualModule);
     }
 
     function getHorizontalForwardQuaternion() {
@@ -776,11 +801,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const controllerState = { horizontal: null, vertical: null };
         vrControllerStates.set(controllerEl, controllerState);
 
-        controllerEl.setAttribute('raycaster', {
-            showLine: true,
-            far: 12
-        });
-
         controllerEl.addEventListener('thumbstickmoved', (event) => {
             const { x = 0, y = 0 } = event.detail || {};
             processControllerAxes(controllerState, x, y);
@@ -802,13 +822,11 @@ document.addEventListener('DOMContentLoaded', () => {
         controllerEl.addEventListener('ybuttondown', triggerVerticalIncrease);
         controllerEl.addEventListener('xbuttondown', triggerVerticalDecrease);
 
-        if (controllerEl.id === 'right-controller') {
-            controllerEl.addEventListener('thumbstickdown', triggerRecenter);
-        }
+        controllerEl.addEventListener('thumbstickdown', triggerRecenter);
     };
 
     const setupVRControllers = () => {
-        const controllerSelector = '#rig [laser-controls]';
+        const controllerSelector = '#rig [laser-controls], #rig [oculus-touch-controls], #rig [tracked-controls]';
         const existingControllers = document.querySelectorAll(controllerSelector);
         existingControllers.forEach((controllerEl) => bindVRController(controllerEl));
 

--- a/main.js
+++ b/main.js
@@ -6,6 +6,31 @@ import { optokineticModule } from './visuals/optokinetic.js';
 import { opticalFlowModule } from './visuals/opticalFlow.js';
 import { heightsModule } from './visuals/heights.js';
 
+const detectQuestHeadset = () => {
+    if (typeof navigator === 'undefined') {
+        return false;
+    }
+
+    const ua = navigator.userAgent || '';
+    if (/OculusBrowser/i.test(ua)) {
+        return true;
+    }
+
+    const uaDataPlatform = navigator.userAgentData && navigator.userAgentData.platform;
+    if (uaDataPlatform && /oculus/i.test(uaDataPlatform)) {
+        return true;
+    }
+
+    const isStandalone = Boolean(AFRAME?.utils?.device?.isStandaloneVR && AFRAME.utils.device.isStandaloneVR());
+    const isMobileVR = Boolean(AFRAME?.utils?.device?.isMobileVR && AFRAME.utils.device.isMobileVR());
+
+    if ((isStandalone || isMobileVR) && /Quest/i.test(ua)) {
+        return true;
+    }
+
+    return false;
+};
+
 // --- A-Frame Component for Exercise Ticking ---
 AFRAME.registerComponent('exercise-ticker', {
     init: function () {
@@ -65,6 +90,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const mobileMediaQuery = window.matchMedia('(max-width: 768px)');
     let activeMobileTabId = 'visual-panel';
 
+    const isQuestPlatform = detectQuestHeadset();
+    if (isQuestPlatform) {
+        document.body.dataset.vrPlatform = 'quest';
+        console.info('[OptoWeb] Plateforme Quest détectée : vitesse optocinétique par défaut fixée à 5 deg/s.');
+    }
+
     // --- State Variables ---
     let activeExerciseModule = null;
     let activeVisualModule = null;
@@ -78,6 +109,8 @@ document.addEventListener('DOMContentLoaded', () => {
         opticalFlow: opticalFlowModule,
         heights: heightsModule
     };
+
+    const visualModuleCycle = ['optokinetic', 'opticalFlow', 'heights'];
 
     // --- Core Functions ---
 
@@ -122,27 +155,32 @@ document.addEventListener('DOMContentLoaded', () => {
         updateUIVisibility(moduleName);
 
         const currentState = stateManager.getState();
+        const initialSpeeds = { h: 0, v: 0, t: 0, y: 0 };
+        if (moduleName === 'optokinetic' && isQuestPlatform) {
+            initialSpeeds.h = 5;
+        }
+
         const baseVisualState = {
             ...currentState.visual,
             activeModule: moduleName,
             altitude: moduleName === 'heights' ? (currentState.visual.altitude ?? 0) : 0,
             platformScale: currentState.visual.platformScale ?? 1,
             heightsDecorDensity: currentState.visual.heightsDecorDensity ?? 'immersive',
-            speeds: { h: 0, v: 0, t: 0, y: 0 }
+            speeds: initialSpeeds
         };
 
         if (!activeVisualModule) {
             if (skyEl) {
                 skyEl.setAttribute('color', '#000000');
             }
-            horizontalSpeedValue.textContent = '0';
-            verticalSpeedValue.textContent = '0';
-            translationSpeedValue.textContent = '0.0';
-            heightSpeedValue.textContent = '0.0';
+            horizontalSpeedValue.textContent = Math.round(initialSpeeds.h);
+            verticalSpeedValue.textContent = Math.round(initialSpeeds.v);
+            translationSpeedValue.textContent = Number(initialSpeeds.t).toFixed(1);
+            heightSpeedValue.textContent = Number(initialSpeeds.y).toFixed(1);
             if (heightAltitudeValue) {
                 heightAltitudeValue.textContent = '0.0';
             }
-            
+
             stateManager.setState({ visual: baseVisualState });
             return;
         }
@@ -151,13 +189,21 @@ document.addEventListener('DOMContentLoaded', () => {
             activeVisualModule.init(sceneEl, rigEl, cameraEl, spheresContainer);
         }
 
-        stateManager.setState({
-            visual: {
-                ...baseVisualState,
-                speeds: { h: 0, v: 0, t: 0, y: 0 }
-            }
-        });
+        stateManager.setState({ visual: baseVisualState });
     }
+
+    const activateNextVisualModule = () => {
+        const currentValue = visualSelect.value;
+        const currentIndex = visualModuleCycle.indexOf(currentValue);
+        const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % visualModuleCycle.length;
+        const nextModule = visualModuleCycle[nextIndex];
+
+        if (nextModule !== currentValue) {
+            visualSelect.value = nextModule;
+        }
+
+        setActiveVisualModule(nextModule);
+    };
 
     function getHorizontalForwardQuaternion() {
         const cameraQuaternion = new THREE.Quaternion();
@@ -682,7 +728,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const vrControllerStates = new WeakMap();
-    const thumbstickThreshold = 0.4;
+    const thumbstickThreshold = 0.25;
 
     const processControllerAxes = (controllerState, x = 0, y = 0) => {
         const nextHorizontal = Math.abs(x) > thumbstickThreshold ? (x > 0 ? 'arrowright' : 'arrowleft') : null;
@@ -732,7 +778,9 @@ document.addEventListener('DOMContentLoaded', () => {
         controllerEl.addEventListener('xbuttondown', triggerVerticalDecrease);
 
         if (controllerEl.id === 'right-controller') {
-            controllerEl.addEventListener('thumbstickdown', triggerRecenter);
+            controllerEl.addEventListener('thumbstickdown', () => {
+                activateNextVisualModule();
+            });
         }
     };
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.88';
+const VERSION = '0.89';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.90';
+const VERSION = '0.91';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 
-const VERSION = '0.89';
+const VERSION = '0.90';
 const scopePath = new URL(self.registration.scope).pathname;
 const normalizedPath = scopePath.replace(/\/+$/, '');
 const pathSegments = normalizedPath.split('/').filter(Boolean);

--- a/styles.css
+++ b/styles.css
@@ -177,6 +177,21 @@ body {
     touch-action: manipulation;
 }
 
+body[data-vr-platform="quest"] .mobile-keypad {
+    display: grid;
+    grid-template-columns: repeat(3, 32px);
+    grid-auto-rows: 32px;
+    justify-content: center;
+    justify-items: center;
+    align-items: center;
+}
+
+body[data-vr-platform="quest"] .mobile-keypad-button {
+    width: 32px;
+    height: 32px;
+    font-size: 0.9em;
+}
+
 .mobile-keypad-button:active {
     background-color: #e4f0ee;
     border-color: #b6d8d4;

--- a/visuals/heights.js
+++ b/visuals/heights.js
@@ -16,11 +16,11 @@ const platformElements = {
     rails: []
 };
 let skyEl;
-let animationFrameId;
 let actualSpeed = 0;
 let targetSpeed = 0;
 const smoothingFactor = 2.0; // Facteur de lissage pour une décélération douce
-let lastFrameTime = 0;
+let isTicking = false;
+let lastTickTime = null;
 let currentAltitude = 0;
 let lastReportedAltitude = null;
 let unsubscribeFromState = null;
@@ -214,9 +214,16 @@ function _applyPlatformScale() {
     platformEl.object3D.scale.set(platformScale, 1, platformScale);
 }
 
-function _animate(time) {
-    const dt = (time - lastFrameTime) / 1000;
-    lastFrameTime = time;
+function _updateFrame(time = performance.now(), timeDelta = 16.6667) {
+    if (!isTicking) {
+        return;
+    }
+
+    const deltaMs = (typeof timeDelta === 'number' && timeDelta > 0)
+        ? timeDelta
+        : (lastTickTime !== null ? time - lastTickTime : 16.6667);
+    lastTickTime = time;
+    const dt = Math.max(deltaMs, 0) / 1000;
 
     // Lisser la vitesse actuelle vers la vitesse cible
     actualSpeed += (targetSpeed - actualSpeed) * (1 - Math.exp(-dt * smoothingFactor));
@@ -226,7 +233,7 @@ function _animate(time) {
         actualSpeed = 0;
     }
 
-    if (rigEl && platformEl && Math.abs(actualSpeed) > 0) {
+    if (rigEl && platformEl && Math.abs(actualSpeed) > 0 && dt > 0) {
         const desiredY = rigEl.object3D.position.y + actualSpeed * dt; // Vitesse par seconde
         const clampedY = Math.min(MAX_ALTITUDE, Math.max(MIN_ALTITUDE, desiredY));
 
@@ -249,8 +256,6 @@ function _animate(time) {
             _reportAltitude(true);
         }
     }
-
-    animationFrameId = requestAnimationFrame(_animate);
 }
 
 // --- Public Interface ---
@@ -286,16 +291,12 @@ export const heightsModule = {
             _applyPlatformScale();
         }
         _applyPlatformTheme();
-        lastFrameTime = performance.now();
+        lastTickTime = null;
         currentAltitude = rigEl ? rigEl.object3D.position.y : BASE_ALTITUDE;
         lastReportedAltitude = null;
         _reportAltitude(true);
 
-        // Lancer correctement la boucle d'animation
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-        }
-        animationFrameId = requestAnimationFrame(_animate);
+        isTicking = true;
     },
 
     onStateChange(newState) {
@@ -327,9 +328,8 @@ export const heightsModule = {
         // Nettoyer le décor via son module dédié
         heightsDecorModule.cleanup();
 
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-        }
+        isTicking = false;
+        lastTickTime = null;
         if (platformEl && platformEl.parentNode) {
             platformEl.parentNode.removeChild(platformEl);
         }
@@ -362,6 +362,10 @@ export const heightsModule = {
             lastReportedAltitude = null;
         }
         _reportAltitude(true);
+    },
+
+    tick(time, timeDelta) {
+        _updateFrame(time, timeDelta);
     },
 
     // --- Fonctions pour les contrôles ---

--- a/visuals/opticalFlow.js
+++ b/visuals/opticalFlow.js
@@ -10,9 +10,9 @@ let targetSpeed = 0; // La vitesse que l'on veut atteindre
 let currentSpeed = 0; // La vitesse actuelle des particules
 const smoothingFactor = 0.12; // Contrôle la fluidité du mouvement (plus c'est petit, plus c'est fluide)
 let density = 100;
-let animationFrameId;
 let stars = [];
-let lastTime = 0; // Pour calculer le timeDelta
+let isTicking = false;
+let lastTickTime = null;
 let selectedPaletteId = 'default';
 let activePaletteColors = colorPalettes.default;
 let autoPaletteInterval = null;
@@ -347,12 +347,16 @@ function _generateStars() {
 }
 
 // --- Animation Logic ---
-function _animate(time) {
-    if (lastTime === 0) {
-        lastTime = time;
+function _updateFrame(time = performance.now(), timeDelta = 16.6667) {
+    if (!isTicking) {
+        return;
     }
-    const timeDelta = time - lastTime;
-    lastTime = time;
+
+    const deltaMs = (typeof timeDelta === 'number' && timeDelta > 0)
+        ? timeDelta
+        : (lastTickTime !== null ? time - lastTickTime : 16.6667);
+    lastTickTime = time;
+    const deltaSeconds = Math.max(deltaMs, 0) / 1000;
 
     currentSpeed += (targetSpeed - currentSpeed) * smoothingFactor;
 
@@ -360,8 +364,7 @@ function _animate(time) {
         currentSpeed = 0;
     }
 
-    if (currentSpeed !== 0 && timeDelta > 0) {
-        const deltaSeconds = timeDelta / 1000;
+    if (currentSpeed !== 0 && deltaSeconds > 0) {
         for (const starData of stars) {
             const position = starData.element.object3D.position;
             position.z += currentSpeed * deltaSeconds * starData.speedFactor;
@@ -406,8 +409,6 @@ function _animate(time) {
             }
         }
     }
-
-    animationFrameId = requestAnimationFrame(_animate);
 }
 
 // --- Public Interface ---
@@ -429,11 +430,8 @@ export const opticalFlowModule = {
 
         _generateStars();
 
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-        }
-        lastTime = 0; // Réinitialiser le temps pour le calcul du delta
-        animationFrameId = requestAnimationFrame(_animate);
+        isTicking = true;
+        lastTickTime = null;
     },
 
     onStateChange(newState) {
@@ -503,15 +501,17 @@ export const opticalFlowModule = {
         _applyPaletteToStars(true);
     },
 
+    tick(time, timeDelta) {
+        _updateFrame(time, timeDelta);
+    },
+
     cleanup() {
         if (unsubscribeFromState) {
             unsubscribeFromState();
             unsubscribeFromState = null;
         }
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-            animationFrameId = null;
-        }
+        isTicking = false;
+        lastTickTime = null;
         _stopAutoPalette();
         if (container) {
             _clearContainerChildren();
@@ -519,6 +519,5 @@ export const opticalFlowModule = {
         stars = [];
         currentSpeed = 0;
         targetSpeed = 0;
-        lastTime = 0;
     }
 };

--- a/visuals/optokinetic.js
+++ b/visuals/optokinetic.js
@@ -9,8 +9,6 @@ let sceneEl, spheresContainer, rigEl, cameraEl;
 let currentPaletteKey = 'default';
 let currentPalette = colorPalettes.default;
 let density = 150;
-let animationFrameId;
-
 let targetSpeedX = 0, targetSpeedY = 0, actualSpeedX = 0, actualSpeedY = 0;
 const smoothingFactor = 1.5;
 let rotationAxisX = new THREE.Vector3(1, 0, 0), rotationAxisY = new THREE.Vector3(0, 1, 0);
@@ -18,14 +16,11 @@ let rotationAxisX = new THREE.Vector3(1, 0, 0), rotationAxisY = new THREE.Vector
 let isRegenerating = false;
 let colorTransition = { isActive: false, duration: 500, startTime: 0, from: [], to: [] };
 let autoCycleInterval = null;
-let lastFrameTime = performance.now();
-let frameCounter = 0;
 
 let instancedMesh = null;
 let instancedGeometry = null;
 let instancedMaterial = null;
 let haloTexture = null;
-let fadeAnimationId = null;
 const MAX_PALETTE_COLORS = 8;
 let unsubscribeFromState = null;
 
@@ -35,6 +30,17 @@ const tempCameraUp = new THREE.Vector3(0, 1, 0);
 const tempCameraDirection = new THREE.Vector3(0, 0, -1);
 
 const palettesUniformTemplate = Array.from({ length: MAX_PALETTE_COLORS }, () => new THREE.Color(0, 0, 0));
+
+let isTicking = false;
+let lastTickTime = null;
+const fadeState = {
+    active: false,
+    startTime: 0,
+    startOpacity: 1,
+    endOpacity: 1,
+    duration: 300,
+    callback: null
+};
 
 
 function _ensureHaloTexture() {
@@ -137,10 +143,8 @@ function _createInstancedMaterial() {
 }
 
 function _disposeInstancedResources() {
-    if (fadeAnimationId) {
-        cancelAnimationFrame(fadeAnimationId);
-        fadeAnimationId = null;
-    }
+    fadeState.active = false;
+    fadeState.callback = null;
     if (instancedMesh && spheresContainer) {
         spheresContainer.object3D.remove(instancedMesh);
     }
@@ -246,31 +250,12 @@ function _fade(direction, callback) {
         return;
     }
 
-    if (fadeAnimationId) {
-        cancelAnimationFrame(fadeAnimationId);
-        fadeAnimationId = null;
-    }
-
-    const duration = 300;
-    const startOpacity = instancedMaterial.uniforms.globalOpacity.value;
-    const endOpacity = direction === 'out' ? 0 : 1;
-    let startTime = null;
-
-    function fadeAnimation(time) {
-        if (!startTime) startTime = time;
-        const elapsed = time - startTime;
-        const progress = Math.min(elapsed / duration, 1);
-        const opacity = THREE.MathUtils.lerp(startOpacity, endOpacity, progress);
-        instancedMaterial.uniforms.globalOpacity.value = opacity;
-
-        if (progress < 1) {
-            fadeAnimationId = requestAnimationFrame(fadeAnimation);
-        } else {
-            fadeAnimationId = null;
-            if (callback) callback();
-        }
-    }
-    fadeAnimationId = requestAnimationFrame(fadeAnimation);
+    fadeState.active = true;
+    fadeState.startTime = performance.now();
+    fadeState.startOpacity = instancedMaterial.uniforms.globalOpacity.value;
+    fadeState.endOpacity = direction === 'out' ? 0 : 1;
+    fadeState.duration = 300;
+    fadeState.callback = typeof callback === 'function' ? callback : null;
 }
 
 
@@ -311,11 +296,36 @@ function _getActiveThreeCamera() {
     return null;
 }
 
-function _animate(time) {
-    animationFrameId = requestAnimationFrame(_animate);
-    frameCounter++;
-    const dt = (time - lastFrameTime) / 1000;
-    lastFrameTime = time;
+function _updateFade(time) {
+    if (!fadeState.active || !instancedMaterial) {
+        return;
+    }
+
+    const elapsed = time - fadeState.startTime;
+    const progress = Math.min(elapsed / fadeState.duration, 1);
+    const opacity = THREE.MathUtils.lerp(fadeState.startOpacity, fadeState.endOpacity, progress);
+    instancedMaterial.uniforms.globalOpacity.value = opacity;
+
+    if (progress >= 1) {
+        fadeState.active = false;
+        const callback = fadeState.callback;
+        fadeState.callback = null;
+        if (typeof callback === 'function') {
+            callback();
+        }
+    }
+}
+
+function _updateFrame(time = performance.now(), timeDelta = 16.6667) {
+    if (!isTicking) {
+        return;
+    }
+
+    const deltaMs = (typeof timeDelta === 'number' && timeDelta > 0)
+        ? timeDelta
+        : (lastTickTime !== null ? time - lastTickTime : 16.6667);
+    lastTickTime = time;
+    const dt = Math.max(deltaMs, 0) / 1000;
 
     const activeCamera = _getActiveThreeCamera();
     if (instancedMaterial && activeCamera) {
@@ -340,7 +350,9 @@ function _animate(time) {
         }
     }
 
-    if (isRegenerating) return;
+    _updateFade(time);
+
+    if (isRegenerating || dt <= 0) return;
 
     actualSpeedX += (targetSpeedX - actualSpeedX) * (1 - Math.exp(-dt * smoothingFactor));
     actualSpeedY += (targetSpeedY - actualSpeedY) * (1 - Math.exp(-dt * smoothingFactor));
@@ -358,7 +370,7 @@ function _animate(time) {
         r.quaternion.premultiply(dy);
         rotationAxisX.applyQuaternion(dy);
     }
-    
+
     // Note: UI update is now handled by main.js
 }
 
@@ -434,10 +446,8 @@ export const optokineticModule = {
 
         _updateRotationAxes();
 
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-        }
-        animationFrameId = requestAnimationFrame(_animate);
+        isTicking = true;
+        lastTickTime = null;
 
         if (currentPaletteKey === 'none') {
             spheresContainer.setAttribute('visible', 'false');
@@ -463,10 +473,8 @@ export const optokineticModule = {
                 colorTransition.isActive = false;
                 currentPalette = colorPalettes.none;
                 currentPaletteKey = 'none';
-                if (fadeAnimationId) {
-                    cancelAnimationFrame(fadeAnimationId);
-                    fadeAnimationId = null;
-                }
+                fadeState.active = false;
+                fadeState.callback = null;
                 if (instancedMaterial) {
                     instancedMaterial.uniforms.globalOpacity.value = 0.0;
                     instancedMaterial.uniforms.mixFactor.value = 0.0;
@@ -526,15 +534,16 @@ export const optokineticModule = {
         // DEPRECATED: La logique est maintenant dans onStateChange
     },
 
+    tick(time, timeDelta) {
+        _updateFrame(time, timeDelta);
+    },
+
     cleanup() {
         if (unsubscribeFromState) {
             unsubscribeFromState();
             unsubscribeFromState = null;
         }
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-            animationFrameId = null;
-        }
+        isTicking = false;
         _stopAutoColorCycle();
         _disposeInstancedResources();
     }

--- a/visuals/optokinetic.js
+++ b/visuals/optokinetic.js
@@ -276,12 +276,38 @@ function _fade(direction, callback) {
 
 // --- Animation Logic (from main.js) ---
 function _getActiveThreeCamera() {
-    if (sceneEl && sceneEl.camera) {
-        return sceneEl.camera;
+    if (sceneEl) {
+        const renderer = sceneEl.renderer;
+        if (renderer && renderer.xr && typeof renderer.xr.getCamera === 'function' && sceneEl.camera) {
+            const xrCamera = renderer.xr.getCamera(sceneEl.camera);
+            if (xrCamera) {
+                if (xrCamera.isArrayCamera && Array.isArray(xrCamera.cameras) && xrCamera.cameras.length > 0) {
+                    return xrCamera.cameras[0];
+                }
+                return xrCamera;
+            }
+        }
+
+        if (sceneEl.camera) {
+            const baseCamera = sceneEl.camera;
+            if (baseCamera.isArrayCamera && Array.isArray(baseCamera.cameras) && baseCamera.cameras.length > 0) {
+                return baseCamera.cameras[0];
+            }
+            return baseCamera;
+        }
     }
+
     if (cameraEl) {
-        return cameraEl.getObject3D('camera') || cameraEl.object3D;
+        const embeddedCamera = cameraEl.getObject3D('camera');
+        if (embeddedCamera) {
+            if (embeddedCamera.isArrayCamera && Array.isArray(embeddedCamera.cameras) && embeddedCamera.cameras.length > 0) {
+                return embeddedCamera.cameras[0];
+            }
+            return embeddedCamera;
+        }
+        return cameraEl.object3D;
     }
+
     return null;
 }
 

--- a/visuals/optokinetic.js
+++ b/visuals/optokinetic.js
@@ -63,6 +63,7 @@ function _createInstancedMaterial() {
     instancedMaterial = new THREE.ShaderMaterial({
         transparent: true,
         depthWrite: false,
+        side: THREE.DoubleSide,
         blending: THREE.AdditiveBlending,
         uniforms: {
             haloTexture: { value: _ensureHaloTexture() },


### PR DESCRIPTION
## Summary
- detect Oculus Quest headsets and preset the optokinetic speed to 5 deg/s when present
- reroute the right thumbstick click to cycle visual modules and lower the stick deadzone for easier vertical control tests
- render optokinetic halos double-sided to aid Quest debugging and bump the app to version 0.89

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f759674bf4832381219e7e213132b1